### PR TITLE
Commands API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY=docs compile
+.DEFAULT_GOAL =compile
+
+docs:
+	cd demo && godot --doctool .. --gdextension-docs
+
+
+compile:
+	scons

--- a/SConstruct
+++ b/SConstruct
@@ -63,6 +63,12 @@ if env["target"] in ["editor", "template_debug"]:
     except AttributeError:
         print("Not including class reference as we're targeting a pre-4.3 baseline.")
 
+
+if env['target'] in ('debug', 'template_debug'):
+    env.Append(CPPDEFINES=['DEBUG_MODE'])
+else:
+    env.Append(CPPDEFINES=['RELEASE_MODE'])
+
 file = "{}{}{}".format(libname, env["suffix"], env["SHLIBSUFFIX"])
 
 if env["platform"] == "macos" or env["platform"] == "ios":

--- a/demo/custom_train_part.gd
+++ b/demo/custom_train_part.gd
@@ -1,16 +1,22 @@
 extends GenericTrainPart
-class_name CustomTrainPart
 
 var _total_time = 0.0
+
 var state = {
     "custom_train_part_calls": 0,
 }
+
+func _enter_tree():
+    register_command("custom_command", self._handle_custom_command)
+
+func _handle_custom_command(p1, p2):
+    log_warning("CUSTOM COMMAND HERE")
 
 func _process_train_part(delta):
     _total_time += delta
     if _total_time > 2:
         _total_time = 0
-        print("Here is a custom train part")
+        log_debug("Here is a custom train part")
         state["custom_train_part_calls"] += 1
 
 func _get_train_part_state():

--- a/demo/debug_button.gd
+++ b/demo/debug_button.gd
@@ -1,0 +1,46 @@
+@tool
+
+extends Button
+class_name DebugButton
+
+var _dirty = false
+var _controller:TrainController
+
+
+
+@export_node_path("TrainController") var controller:NodePath:
+    set(x):
+        _dirty = true
+        controller = x
+
+
+@export var command:String
+@export var command_argument:String
+
+func _ready():
+    _dirty = true
+var _t = 0.0
+
+func _process(delta):
+    if _dirty:
+        _dirty = false
+
+        if not _controller and not controller.is_empty():
+            _controller = get_node(controller)
+            disabled = false
+        else:
+            disabled = true
+
+    if not Engine.is_editor_hint():
+        _t += delta
+        if _t > 0.1:
+            _t = 0.0
+            if _controller:
+                disabled = false
+            else:
+                disabled = true
+
+
+func _on_pressed():
+    if _controller and command:
+        _controller.send_command(command, command_argument)

--- a/demo/debug_button.tscn
+++ b/demo/debug_button.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://dy8wkx8wr4gjf"]
+
+[ext_resource type="Script" path="res://debug_button.gd" id="1_e1dhy"]
+
+[node name="DebugButton" type="Button"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+disabled = true
+script = ExtResource("1_e1dhy")
+
+[connection signal="pressed" from="." to="." method="_on_pressed"]

--- a/demo/debug_knob.gd
+++ b/demo/debug_knob.gd
@@ -1,0 +1,81 @@
+@tool
+
+extends Control
+class_name DebugKnob
+
+var _dirty = false
+var _controller:TrainController
+
+
+@export var label:String:
+    set(x):
+        _dirty = true
+        label = x
+
+@export var min_value:float = 0.0:
+    set(x):
+        _dirty = true
+        min_value = x
+
+@export var max_value:float = 1.0:
+    set(x):
+        _dirty = true
+        max_value = x
+
+@export var step:float = 0.1:
+    set(x):
+        _dirty = true
+        step = x
+
+@export_node_path("TrainController") var controller:NodePath:
+    set(x):
+        _dirty = true
+        controller = x
+
+@export var state_property:String:
+    set(x):
+        _dirty = true
+        state_property = x
+
+@export var command:String
+
+func _ready():
+    _dirty = true
+var _t = 0.0
+
+func _process(delta):
+    if _dirty:
+        _dirty = false
+
+        $SpinBox.min_value = min_value
+        $SpinBox.max_value = max_value
+        $SpinBox.step = step
+
+        $Label.text = label
+        if not _controller and not controller.is_empty():
+            _controller = get_node(controller)
+            #$SpinBox.disabled = false
+        else:
+            pass
+            #$SpinBox.disabled = true
+
+    if not Engine.is_editor_hint():
+        _t += delta
+        if _t > 0.1:
+            _t = 0.0
+            if _controller:
+                if state_property:
+                    var value = _controller.state.get(state_property)
+                    if not value == null:
+                        $SpinBox.value = value
+                else:
+                    pass
+                    #$SpinBox.disabled = false
+            else:
+                pass
+                #$SpinBox.disabled = true
+
+
+func _on_spin_box_value_changed(value):
+    if _controller and command:
+        _controller.send_command(command, value)

--- a/demo/debug_knob.tscn
+++ b/demo/debug_knob.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://ddag4vhhuox0t"]
+
+[ext_resource type="Script" path="res://debug_knob.gd" id="1_an08j"]
+
+[node name="DebugKnob" type="HBoxContainer"]
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("1_an08j")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+
+[node name="SpinBox" type="SpinBox" parent="."]
+layout_mode = 2
+max_value = 1.0
+step = 0.1
+
+[connection signal="value_changed" from="SpinBox" to="." method="_on_spin_box_value_changed"]

--- a/demo/debug_switch.gd
+++ b/demo/debug_switch.gd
@@ -67,12 +67,12 @@ func _process(delta):
 
 func _on_switch_toggled(toggled_on):
     if $Switch.action_mode == Button.ACTION_MODE_BUTTON_RELEASE and _controller and command:
-        _controller.receive_command(command, toggled_on)
+        _controller.send_command(command, toggled_on)
 
 func _on_switch_pressed():
     if $Switch.action_mode == Button.ACTION_MODE_BUTTON_PRESS and _controller and command:
-        _controller.receive_command(command, $Switch.button_pressed)
+        _controller.send_command(command, $Switch.button_pressed)
 
 func _on_switch_button_up():
     if not type == SwitchType.MONOSTABLE:
-        _controller.receive_command(command, $Switch.button_pressed)
+        _controller.send_command(command, $Switch.button_pressed)

--- a/demo/demo.gd
+++ b/demo/demo.gd
@@ -2,10 +2,10 @@ extends Control
 
 var _t:float = 0.0
 
-@onready var train = $SM42_V1
-@onready var brake = $SM42_V1/Brake
-@onready var engine = $SM42_V1/StonkaDieselEngine
-@onready var security = $SM42_V1/TrainSecuritySystem
+@onready var train = $SM42
+@onready var brake = $SM42/Brake
+@onready var engine = $SM42/StonkaDieselEngine
+@onready var security = $SM42/TrainSecuritySystem
 
 
 # Called when the node enters the scene tree for the first time.
@@ -27,10 +27,8 @@ func _process(delta: float) -> void:
     if(_t>0.1):
         _t = 0
 
-        var train_state = train.get_mover_state()
+        var train_state = train.get_state()
         var bv = train_state.get("battery_voltage")
-
-        $%CustomTrainPartCount.text = "%s" % train.state.get("custom_train_part_calls")
 
         $%BatteryProgressBar.value = bv
         $%BatteryValue.text = "%.2f V" % [bv]
@@ -52,16 +50,20 @@ func _process(delta: float) -> void:
 
 
 func _on_brake_level_value_changed(value):
-    train.receive_command("brake_level_set", value)
+    TrainSystem.broadcast_command("brake_level_set", value, null)
 
 func _on_main_decrease_button_up():
-    train.receive_command("main_controller_decrease")
+    train.send_command("main_controller_decrease")
 
 func _on_main_increase_button_up():
-    train.receive_command("main_controller_increase")
+    train.send_command("main_controller_increase")
 
 func _on_reverse_button_up():
-    train.receive_command("forwarder_decrease")
+    train.send_command("direction_decrease")
 
 func _on_forward_button_up():
-    train.receive_command("forwarder_increase")
+    train.send_command("direction_increase")
+
+
+func _on_sm_42_mover_initialized():
+    print("Mover initialized. Train config: ", $SM42.config)

--- a/demo/demo.tscn
+++ b/demo/demo.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=7 format=3 uid="uid://djqacw65swdqc"]
+[gd_scene load_steps=9 format=3 uid="uid://djqacw65swdqc"]
 
 [ext_resource type="Script" path="res://demo.gd" id="1_76ghk"]
+[ext_resource type="PackedScene" uid="uid://dgm10m7u26drx" path="res://addons/libmaszyna/developer_console.tscn" id="2_fdv2n"]
 [ext_resource type="PackedScene" uid="uid://c5hi8nsm1d2hb" path="res://sm_42v_1.tscn" id="2_t8uqe"]
 [ext_resource type="PackedScene" uid="uid://1v37c7y4cwcx" path="res://gauge.tscn" id="3_dosfj"]
 [ext_resource type="PackedScene" uid="uid://br6moafqr8ykn" path="res://debug_panel.tscn" id="3_p4ciw"]
 [ext_resource type="PackedScene" uid="uid://cslby72tp46ig" path="res://debug_switch.tscn" id="4_xvhus"]
-[ext_resource type="Script" path="res://powered_train_part_example.gd" id="6_2wkl6"]
+[ext_resource type="PackedScene" uid="uid://dy8wkx8wr4gjf" path="res://debug_button.tscn" id="6_al2d2"]
+[ext_resource type="PackedScene" uid="uid://ddag4vhhuox0t" path="res://debug_knob.tscn" id="7_0xh05"]
 
 [node name="Demo" type="Control"]
 layout_mode = 3
@@ -17,6 +19,8 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_76ghk")
+
+[node name="DeveloperConsole" parent="." instance=ExtResource("2_fdv2n")]
 
 [node name="EngineRPM" parent="." instance=ExtResource("3_dosfj")]
 position = Vector2(0, 453)
@@ -110,19 +114,6 @@ unique_name_in_owner = true
 layout_mode = 2
 title = "Train"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="UI"]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="Label" type="Label" parent="UI/HBoxContainer"]
-layout_mode = 2
-text = "Custom train part calls count:"
-
-[node name="CustomTrainPartCount" type="Label" parent="UI/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "0"
-
 [node name="MoverSwitches" type="HBoxContainer" parent="UI"]
 layout_mode = 2
 
@@ -136,7 +127,7 @@ text = "General"
 [node name="Battery" parent="UI/MoverSwitches/General" instance=ExtResource("4_xvhus")]
 layout_mode = 2
 label = "Battery"
-controller = NodePath("../../../../SM42_V1")
+controller = NodePath("../../../../SM42")
 state_property = "battery_enabled"
 command = "battery"
 
@@ -167,7 +158,7 @@ text = "Security"
 layout_mode = 2
 label = "CA/SHP"
 type = 1
-controller = NodePath("../../../../SM42_V1")
+controller = NodePath("../../../../SM42")
 command = "security_acknowledge"
 
 [node name="Diesel" type="HFlowContainer" parent="UI/MoverSwitches"]
@@ -181,7 +172,7 @@ text = "Diesel"
 layout_mode = 2
 label = "Oil Pump"
 type = 1
-controller = NodePath("../../../../SM42_V1")
+controller = NodePath("../../../../SM42")
 state_property = "oil_pump_active"
 command = "oil_pump"
 
@@ -189,7 +180,7 @@ command = "oil_pump"
 layout_mode = 2
 label = "Fuel Pump"
 type = 1
-controller = NodePath("../../../../SM42_V1")
+controller = NodePath("../../../../SM42")
 state_property = "fuel_pump_active"
 command = "fuel_pump"
 
@@ -197,8 +188,8 @@ command = "fuel_pump"
 layout_mode = 2
 label = "Main"
 type = 0
-controller = NodePath("../../../../SM42_V1")
-state_property = "main_switch"
+controller = NodePath("../../../../SM42")
+state_property = "main_switch_enabled"
 command = "main_switch"
 
 [node name="Electric" type="HFlowContainer" parent="UI/MoverSwitches"]
@@ -226,30 +217,67 @@ layout_mode = 2
 
 [node name="Label" type="Label" parent="UI/MoverSwitches/Brakes"]
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Brakes"
 
-[node name="BrakeLevel" type="SpinBox" parent="UI/MoverSwitches/Brakes"]
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/MoverSwitches/Brakes"]
 layout_mode = 2
 
-[node name="Releaser" parent="UI/MoverSwitches/Brakes" instance=ExtResource("4_xvhus")]
+[node name="Drive" parent="UI/MoverSwitches/Brakes/VBoxContainer" instance=ExtResource("6_al2d2")]
+layout_mode = 2
+disabled = false
+text = "Drive"
+controller = NodePath("../../../../../SM42")
+command = "brake_level_set_position"
+command_argument = "drive"
+
+[node name="Full" parent="UI/MoverSwitches/Brakes/VBoxContainer" instance=ExtResource("6_al2d2")]
+layout_mode = 2
+disabled = false
+text = "Full"
+controller = NodePath("../../../../../SM42")
+command = "brake_level_set_position"
+command_argument = "full"
+
+[node name="Emergency" parent="UI/MoverSwitches/Brakes/VBoxContainer" instance=ExtResource("6_al2d2")]
+layout_mode = 2
+disabled = false
+text = "Emergency"
+controller = NodePath("../../../../../SM42")
+command = "brake_level_set_position"
+command_argument = "emergency"
+
+[node name="Level" parent="UI/MoverSwitches/Brakes/VBoxContainer" instance=ExtResource("7_0xh05")]
+layout_mode = 2
+label = "Level"
+step = 0.05
+controller = NodePath("../../../../../SM42")
+state_property = "brake_controller_position_normalized"
+command = "brake_level_set"
+
+[node name="BrakeLevel" type="SpinBox" parent="UI/MoverSwitches/Brakes/VBoxContainer"]
+layout_mode = 2
+max_value = 1.0
+step = 0.01
+
+[node name="Releaser" parent="UI/MoverSwitches/Brakes/VBoxContainer" instance=ExtResource("4_xvhus")]
 layout_mode = 2
 label = "Releaser"
 type = 1
-controller = NodePath("../../../../SM42_V1")
+controller = NodePath("../../../../../SM42")
 command = "brake_releaser"
 
-[node name="SM42_V1" parent="." instance=ExtResource("2_t8uqe")]
+[node name="SM42" parent="." instance=ExtResource("2_t8uqe")]
+train_id = "sm42"
 
-[node name="TestowySilnikElektryczny" parent="SM42_V1" index="1"]
+[node name="TestowySilnikElektryczny" parent="SM42" index="1"]
 enabled = false
-
-[node name="PoweredTrainPart" type="GenericTrainPart" parent="SM42_V1"]
-script = ExtResource("6_2wkl6")
 
 [connection signal="button_up" from="UI/MoverSwitches/General/MainIncrease" to="." method="_on_main_increase_button_up"]
 [connection signal="button_up" from="UI/MoverSwitches/General/MainDecrease" to="." method="_on_main_decrease_button_up"]
 [connection signal="button_up" from="UI/MoverSwitches/General/Forward" to="." method="_on_forward_button_up"]
 [connection signal="button_up" from="UI/MoverSwitches/General/Reverse" to="." method="_on_reverse_button_up"]
-[connection signal="value_changed" from="UI/MoverSwitches/Brakes/BrakeLevel" to="." method="_on_brake_level_value_changed"]
+[connection signal="value_changed" from="UI/MoverSwitches/Brakes/VBoxContainer/BrakeLevel" to="." method="_on_brake_level_value_changed"]
+[connection signal="mover_initialized" from="SM42" to="." method="_on_sm_42_mover_initialized"]
 
-[editable path="SM42_V1"]
+[editable path="SM42"]

--- a/demo/example_train.tscn
+++ b/demo/example_train.tscn
@@ -1,7 +1,0 @@
-[gd_scene format=3 uid="uid://clt6kosjdfdfx"]
-
-[node name="ExampleTrain" type="TrainController"]
-parts/brake = NodePath("Brake")
-
-[node name="Brake" type="TrainBrake" parent="."]
-process_priority = 1

--- a/demo/examples/custom_powered_train_part.tscn
+++ b/demo/examples/custom_powered_train_part.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://dhir05gi7u6by"]
+
+[ext_resource type="Script" path="res://examples/powered_train_part_example.gd" id="1_1fn40"]
+[ext_resource type="PackedScene" uid="uid://dgm10m7u26drx" path="res://addons/libmaszyna/developer_console.tscn" id="1_vsgvw"]
+[ext_resource type="PackedScene" uid="uid://clt6kosjdfdfx" path="res://examples/example_train.tscn" id="2_ep4dj"]
+
+[node name="CustomPoweredTrainPart" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="DeveloperConsole" parent="." instance=ExtResource("1_vsgvw")]
+visible = true
+
+[node name="train1" parent="." instance=ExtResource("2_ep4dj")]
+train_id = "train1"
+
+[node name="PoweredTrainPart" type="GenericTrainPart" parent="train1"]
+script = ExtResource("1_1fn40")

--- a/demo/examples/custom_train_part.tscn
+++ b/demo/examples/custom_train_part.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3 uid="uid://cvf3h3bnqo1my"]
+
+[ext_resource type="Script" path="res://custom_train_part.gd" id="1_wmqlj"]
+[ext_resource type="PackedScene" uid="uid://dgm10m7u26drx" path="res://addons/libmaszyna/developer_console.tscn" id="2_l7ubh"]
+[ext_resource type="PackedScene" uid="uid://clt6kosjdfdfx" path="res://examples/example_train.tscn" id="2_qm6os"]
+
+[node name="CustomTrainPart" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="DeveloperConsole" parent="." instance=ExtResource("2_l7ubh")]
+visible = true
+
+[node name="train1" parent="." instance=ExtResource("2_qm6os")]
+train_id = "train1"
+
+[node name="CustomTrainPart" type="GenericTrainPart" parent="train1"]
+script = ExtResource("1_wmqlj")

--- a/demo/examples/example_train.tscn
+++ b/demo/examples/example_train.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=3 uid="uid://clt6kosjdfdfx"]
+
+[node name="ExampleTrain" type="TrainController"]
+train_id = "exampletrain"
+battery_voltage = 110.0
+
+[node name="Brake" type="TrainBrake" parent="."]
+process_priority = 1
+
+[node name="TrainSecuritySystem" type="TrainSecuritySystem" parent="."]
+
+[node name="TrainDieselElectricEngine" type="TrainDieselElectricEngine" parent="."]

--- a/demo/examples/powered_train_part_example.gd
+++ b/demo/examples/powered_train_part_example.gd
@@ -6,10 +6,10 @@ func _process_powered(delta):
     _t += delta
     if _t > 2.0:
         _t = 0.0
-        print("Powered train part example: POWERED")
+        log_debug("Powered train part example: POWERED")
 
 func _process_unpowered(delta):
     _t += delta
     if _t > 2.0:
         _t = 0.0
-        print("Powered train part example: UNPOWERED")
+        log_debug("Powered train part example: UNPOWERED")

--- a/demo/globals.gd
+++ b/demo/globals.gd
@@ -1,0 +1,1 @@
+extends Node

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -14,3 +14,18 @@ config/name="LibMaszyna Demo"
 run/main_scene="res://demo.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
+
+[autoload]
+
+Console="*res://addons/libmaszyna/console.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/libmaszyna/plugin.cfg")
+
+[input]
+
+brake_level_set={
+"deadzone": 0.5,
+"events": []
+}

--- a/demo/sm_42v_1.tscn
+++ b/demo/sm_42v_1.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=3 format=3 uid="uid://c5hi8nsm1d2hb"]
+[gd_scene load_steps=2 format=3 uid="uid://c5hi8nsm1d2hb"]
 
-[ext_resource type="Script" path="res://custom_train_part.gd" id="1_2wure"]
 [ext_resource type="Script" path="res://sm_42v_1.gd" id="1_vib8j"]
 
 [node name="SM42v1" type="TrainController"]
@@ -61,6 +60,3 @@ emergency_brake_delay = 2.5
 sound_signal_delay = 2.5
 shp_magnet_distance = 3.0
 ca_max_hold_time = 1.0
-
-[node name="CustomTrainPart" type="GenericTrainPart" parent="."]
-script = ExtResource("1_2wure")

--- a/doc_classes/GenericTrainPart.xml
+++ b/doc_classes/GenericTrainPart.xml
@@ -25,7 +25,8 @@
 		<method name="get_train_state">
 			<return type="Dictionary" />
 			<description>
-				Returns a [Dictionary] with a current state of the [GenericPart]
+				Returns a [Dictionary] with a current state of the [TrainController].
+				This is a shortcut for [method TrainController.get_state] and [method TrainSystem.get_train_state].
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/TrainBrake.xml
+++ b/doc_classes/TrainBrake.xml
@@ -8,6 +8,42 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="brake_level_decrease">
+			<return type="void" />
+			<description>
+				Decrease brake level by one position
+			</description>
+		</method>
+		<method name="brake_level_increase">
+			<return type="void" />
+			<description>
+				Increase brake level by one position
+			</description>
+		</method>
+		<method name="brake_level_set">
+			<return type="void" />
+			<param index="0" name="level" type="float" />
+			<description>
+				Set brake level between 0.0 and 1.0. 
+				See also [method brake_level_set_position].
+			</description>
+		</method>
+		<method name="brake_level_set_position">
+			<return type="void" />
+			<param index="0" name="position" type="int" enum="TrainBrake.BrakeHandlePosition" />
+			<description>
+				Set brake level position by using predefined value
+			</description>
+		</method>
+		<method name="brake_releaser">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate brake releaser
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="brake_force/max" type="float" setter="set_max_brake_force" getter="get_max_brake_force" default="1.0">
 			[code]Brake:MBF[/code]
@@ -111,6 +147,16 @@
 		<constant name="COMPRESSOR_POWER_COUPLER1" value="4" enum="CompressorPower">
 		</constant>
 		<constant name="COMPRESSOR_POWER_COUPLER2" value="5" enum="CompressorPower">
+		</constant>
+		<constant name="BRAKE_HANDLE_POSITION_MIN" value="0" enum="BrakeHandlePosition">
+		</constant>
+		<constant name="BRAKE_HANDLE_POSITION_MAX" value="1" enum="BrakeHandlePosition">
+		</constant>
+		<constant name="BRAKE_HANDLE_POSITION_DRIVE" value="2" enum="BrakeHandlePosition">
+		</constant>
+		<constant name="BRAKE_HANDLE_POSITION_FULL" value="3" enum="BrakeHandlePosition">
+		</constant>
+		<constant name="BRAKE_HANDLE_POSITION_EMERGENCY" value="4" enum="BrakeHandlePosition">
 		</constant>
 		<constant name="BRAKE_VALVE_NO_VALVE" value="0" enum="TrainBrakeValve">
 		</constant>

--- a/doc_classes/TrainController.xml
+++ b/doc_classes/TrainController.xml
@@ -4,30 +4,119 @@
 		Base train controller controlling all train systems
 	</brief_description>
 	<description>
-		Base train controller
+		Base train controller node. Allows to build behaviour of the train by adding child nodes of the [TrainPart] class.
+		When node is added to the scene tree, the train is automatically registered in the [TrainSystem] with an unique identifier [member TrainController.train_id].
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_mover_state">
-			<return type="Dictionary" />
+		<method name="battery">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
 			<description>
-				Returns dictionary of values from iternal mover
+				Turn on/off train battery
 			</description>
 		</method>
-		<method name="receive_command">
+		<method name="broadcast_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="p1" type="Variant" default="null" />
+			<param index="2" name="p2" type="Variant" default="null" />
+			<description>
+				Broadcasts command to all trains (including self)
+			</description>
+		</method>
+		<method name="direction_decrease">
+			<return type="void" />
+			<description>
+				Increase direction by one step
+			</description>
+		</method>
+		<method name="direction_increase">
+			<return type="void" />
+			<description>
+				Decrease direction by one step
+			</description>
+		</method>
+		<method name="main_controller_decrease">
+			<return type="void" />
+			<param index="0" name="step" type="int" default="1" />
+			<description>
+				Decrease main controller position
+			</description>
+		</method>
+		<method name="main_controller_increase">
+			<return type="void" />
+			<param index="0" name="step" type="int" default="1" />
+			<description>
+				Increase main controller position
+			</description>
+		</method>
+		<method name="radio">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Turn on/off the radio
+			</description>
+		</method>
+		<method name="radio_channel_decrease">
+			<return type="void" />
+			<param index="0" name="step" type="int" default="1" />
+			<description>
+				Decrease radio channel
+			</description>
+		</method>
+		<method name="radio_channel_increase">
+			<return type="void" />
+			<param index="0" name="step" type="int" default="1" />
+			<description>
+				Increase radio channel
+			</description>
+		</method>
+		<method name="register_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Registers command for train controlled by this node.
+				This is a shortcut for [method TrainSystem.register_command].
+			</description>
+		</method>
+		<method name="send_command">
 			<return type="void" />
 			<param index="0" name="command" type="StringName" />
 			<param index="1" name="p1" type="Variant" default="null" />
 			<param index="2" name="p2" type="Variant" default="null" />
 			<description>
-				Schedules a command to be processed by train and it's parts.
+				Sends command to train controlled by this node.
+				This is a shortcut for [method TrainSystem.send_command].
 			</description>
 		</method>
-		<method name="update_mover" qualifiers="const">
+		<method name="unregister_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Removes command of a train controlled by this node from the registry.
+				This is a shortcut for [method TrainSystem.unregister_command].
+			</description>
+		</method>
+		<method name="update_config">
+			<return type="void" />
+			<param index="0" name="_unnamed_arg0" type="Dictionary" />
+			<description>
+			</description>
+		</method>
+		<method name="update_mover" experimental="true">
 			<return type="void" />
 			<description>
-				Updates iternal mover
+				Updates iternal mover based on the config stored in node properties (should not be called directly)
+			</description>
+		</method>
+		<method name="update_state" experimental="true">
+			<return type="void" />
+			<description>
+				Forces update of the state (should not be called directly)
 			</description>
 		</method>
 	</methods>
@@ -37,6 +126,10 @@
 		</member>
 		<member name="battery_voltage" type="float" setter="set_battery_voltage" getter="get_battery_voltage" default="0.0">
 			[code]Light:LMaxVoltage[/code]
+		</member>
+		<member name="config" type="Dictionary" setter="" getter="get_config" default="{}">
+			Returns a dictionary with all config properties of the train.
+			This is a shortcut for iterating over [method TrainSystem.get_supported_config_properties] to read each from [method TrainSystem.get_config_property].
 		</member>
 		<member name="dimensions/mass" type="float" setter="set_mass" getter="get_mass" default="0.0">
 			[code]Param.M[/code] Mass of the train
@@ -53,11 +146,14 @@
 		<member name="radio/channel_min" type="int" setter="set_radio_channel_min" getter="get_radio_channel_min" default="0">
 			Minimum radio channel number
 		</member>
-		<member name="state" type="Dictionary" setter="set_state" getter="get_state" default="{}">
+		<member name="state" type="Dictionary" setter="" getter="get_state" default="{}">
 			Actual state of the train
 		</member>
+		<member name="train_id" type="String" setter="set_train_id" getter="get_train_id" default="&quot;train&quot;">
+			Unique identifier of the train. See [method TrainSystem.register_train].
+		</member>
 		<member name="type_name" type="String" setter="set_type_name" getter="get_type_name" default="&quot;&quot;">
-			Train type name 
+			Train type name
 		</member>
 	</members>
 	<signals>
@@ -66,7 +162,12 @@
 			<param index="1" name="p1" type="Variant" />
 			<param index="2" name="p2" type="Variant" />
 			<description>
-				Train received a command
+				Emitted when train receives a command
+			</description>
+		</signal>
+		<signal name="config_changed">
+			<description>
+				Train configuration changed
 			</description>
 		</signal>
 		<signal name="mover_config_changed">
@@ -74,10 +175,21 @@
 				Train internal configuration changed
 			</description>
 		</signal>
+		<signal name="mover_initialized">
+			<description>
+				Train internal subsystem initialized
+			</description>
+		</signal>
 		<signal name="power_changed">
 			<param index="0" name="is_powered" type="bool" />
 			<description>
 				Train power state changed
+			</description>
+		</signal>
+		<signal name="radio_channel_changed">
+			<param index="0" name="channel" type="int" />
+			<description>
+				Emitted when selected radio channel changes
 			</description>
 		</signal>
 		<signal name="radio_toggled">

--- a/doc_classes/TrainDieselEngine.xml
+++ b/doc_classes/TrainDieselEngine.xml
@@ -8,6 +8,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="fuel_pump">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate fuel pump
+			</description>
+		</method>
+		<method name="oil_pump">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate oil pump
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="Ftmax" type="float" setter="set_traction_force_max" getter="get_traction_force_max" default="0.0">
 			[code]Engine:Ftmax[/code]

--- a/doc_classes/TrainElectricEngine.xml
+++ b/doc_classes/TrainElectricEngine.xml
@@ -8,6 +8,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="compressor">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate compressor
+			</description>
+		</method>
+		<method name="converter">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate converter
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="power/accumulator/recharge_source" type="int" setter="set_accumulator_recharge_source" getter="get_accumulator_recharge_source" enum="TrainElectricEngine.TrainPowerSource" default="0">
 			Power source for recharging the accumulator
@@ -56,9 +72,6 @@
 		</member>
 		<member name="power/transducer/input_voltage" type="float" setter="set_transducer_input_voltage" getter="get_transducer_input_voltage" default="0.0">
 			Input voltage for the transducer
-		</member>
-		<member name="switches/converter" type="bool" setter="set_converter_switch_pressed" getter="get_converter_switch_pressed" default="false">
-			Is the converter on
 		</member>
 	</members>
 	<constants>

--- a/doc_classes/TrainEngine.xml
+++ b/doc_classes/TrainEngine.xml
@@ -8,6 +8,15 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="main_switch">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Operate main switch
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="motor_param_table" type="Dictionary[]" setter="set_motor_param_table" getter="get_motor_param_table" default="[]">
 			[code]MotorParamTable[/code]

--- a/doc_classes/TrainPart.xml
+++ b/doc_classes/TrainPart.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TrainPart" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
-		Basic train part class. Handles all engines etc.
+		Basic class of the train part.
 	</brief_description>
 	<description>
-		Basic train part class
+		A base class for creating a specialized behaviours of the train. Provides shortcuts for most important methods.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="broadcast_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="p1" type="Variant" default="null" />
+			<param index="2" name="p2" type="Variant" default="null" />
+			<description>
+				Broadcast command to all trains (including the train, which part belongs to)
+			</description>
+		</method>
 		<method name="emit_config_changed_signal">
 			<return type="void" />
 			<description>
@@ -21,13 +30,67 @@
 				Returns dictionary ov properties with values from iternal mover
 			</description>
 		</method>
-		<method name="on_command_received">
+		<method name="log">
 			<return type="void" />
-			<param index="0" name="_unnamed_arg0" type="String" />
-			<param index="1" name="_unnamed_arg1" type="Variant" />
-			<param index="2" name="_unnamed_arg2" type="Variant" />
+			<param index="0" name="loglevel" type="int" enum="TrainSystem.TrainLogLevel" />
+			<param index="1" name="line" type="String" />
 			<description>
-				Handles a command received by [TrainController]
+				Logs a message
+			</description>
+		</method>
+		<method name="log_debug">
+			<return type="void" />
+			<param index="0" name="line" type="String" />
+			<description>
+				Logs a debug message. See [TrainLogLevel].
+			</description>
+		</method>
+		<method name="log_error">
+			<return type="void" />
+			<param index="0" name="line" type="String" />
+			<description>
+				Logs an error message. See [TrainLogLevel].
+			</description>
+		</method>
+		<method name="log_info">
+			<return type="void" />
+			<param index="0" name="line" type="String" />
+			<description>
+				Logs an info message. See [TrainLogLevel].
+			</description>
+		</method>
+		<method name="log_warning">
+			<return type="void" />
+			<param index="0" name="line" type="String" />
+			<description>
+				Logs a warning message. See [TrainLogLevel].
+			</description>
+		</method>
+		<method name="register_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Registers command for train controlled by this node.
+				This is a shortcut for [method TrainSystem.register_command].
+			</description>
+		</method>
+		<method name="send_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="p1" type="Variant" default="null" />
+			<param index="2" name="p2" type="Variant" default="null" />
+			<description>
+				Sends command to the train, which part belongs to.
+			</description>
+		</method>
+		<method name="unregister_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Removes command of a train controlled by this node from the registry.
+				This is a shortcut for [method TrainSystem.unregister_command].
 			</description>
 		</method>
 		<method name="update_mover">

--- a/doc_classes/TrainSecuritySystem.xml
+++ b/doc_classes/TrainSecuritySystem.xml
@@ -8,6 +8,16 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="security_acknowledge">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<description>
+				Enable or disable security acknowledge signal.
+				Leaving this option on for a longer period of time will first trigger the alarm and then the emergency brakes will be activated after a while.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="aware_delay" type="float" setter="set_aware_delay" getter="get_aware_delay" default="0.0">
 			[code]Security:AwareDelay[/code]

--- a/doc_classes/TrainSystem.xml
+++ b/doc_classes/TrainSystem.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TrainSystem" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Handles trains registry and communication between trains and train systems
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="broadcast_command">
+			<return type="void" />
+			<param index="0" name="command" type="String" />
+			<param index="1" name="p1" type="Variant" default="null" />
+			<param index="2" name="p2" type="Variant" default="null" />
+			<description>
+				Broadcast command to all registered trains
+			</description>
+		</method>
+		<method name="get_all_config_properties">
+			<return type="Dictionary" />
+			<param index="0" name="train_id" type="String" />
+			<description>
+				Returns all config properties for the train
+			</description>
+		</method>
+		<method name="get_config_property">
+			<return type="Variant" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="property_name" type="String" />
+			<description>
+				Reads value of a train's config property.
+			</description>
+		</method>
+		<method name="get_registered_trains">
+			<return type="Array" />
+			<description>
+				Return list of registered [TrainController]s.
+			</description>
+		</method>
+		<method name="get_supported_commands">
+			<return type="Array" />
+			<description>
+				Return all supported commands
+			</description>
+		</method>
+		<method name="get_supported_config_properties">
+			<return type="Array" />
+			<param index="0" name="train_id" type="String" />
+			<description>
+				Returns a list of supported config properties by train
+			</description>
+		</method>
+		<method name="get_train_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns number of registered trains
+			</description>
+		</method>
+		<method name="get_train_state">
+			<return type="Dictionary" />
+			<param index="0" name="train_id" type="String" />
+			<description>
+				Returns the current state of the train
+			</description>
+		</method>
+		<method name="global_log">
+			<return type="void" />
+			<param index="0" name="loglevel" type="int" enum="TrainSystem.TrainLogLevel" />
+			<param index="1" name="line" type="String" />
+			<description>
+				Logs a global message
+			</description>
+		</method>
+		<method name="is_command_supported">
+			<return type="bool" />
+			<param index="0" name="command" type="String" />
+			<description>
+				Checks whether command is supported
+			</description>
+		</method>
+		<method name="log">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="loglevel" type="int" enum="TrainSystem.TrainLogLevel" />
+			<param index="2" name="line" type="String" />
+			<description>
+				Logs message related to a train
+			</description>
+		</method>
+		<method name="register_command">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="command" type="String" />
+			<param index="2" name="callable" type="Callable" />
+			<description>
+				Registers a handler for the specified command.
+				New commands are automatically added to the registry.
+			</description>
+		</method>
+		<method name="register_train">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="train" type="TrainController" />
+			<description>
+				Registers a [TrainController] with an unique ID
+			</description>
+		</method>
+		<method name="send_command">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="command" type="String" />
+			<param index="2" name="p1" type="Variant" default="null" />
+			<param index="3" name="p2" type="Variant" default="null" />
+			<description>
+				Sends a command to a specified train
+			</description>
+		</method>
+		<method name="unregister_command">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<param index="1" name="command" type="String" />
+			<param index="2" name="callable" type="Callable" />
+			<description>
+				Removes train's command handler.
+				If the handler was last, the command is removed from the registry.
+			</description>
+		</method>
+		<method name="unregister_train">
+			<return type="void" />
+			<param index="0" name="train_id" type="String" />
+			<description>
+				Removes train from the registry
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="log_updated">
+			<param index="0" name="loglevel" type="int" />
+			<param index="1" name="line" type="String" />
+			<description>
+				Emitted on a new global log message
+			</description>
+		</signal>
+		<signal name="train_log_updated">
+			<param index="0" name="train" type="String" />
+			<param index="1" name="loglevel" type="int" />
+			<param index="2" name="line" type="String" />
+			<description>
+				Emitted on a new train log message
+			</description>
+		</signal>
+	</signals>
+	<constants>
+		<constant name="TRAINLOGLEVEL_DEBUG" value="0" enum="TrainLogLevel">
+		</constant>
+		<constant name="TRAINLOGLEVEL_INFO" value="1" enum="TrainLogLevel">
+		</constant>
+		<constant name="TRAINLOGLEVEL_WARNING" value="2" enum="TrainLogLevel">
+		</constant>
+		<constant name="TRAINLOGLEVEL_ERROR" value="3" enum="TrainLogLevel">
+		</constant>
+	</constants>
+</class>

--- a/gdscripts/console.gd
+++ b/gdscripts/console.gd
@@ -1,0 +1,391 @@
+extends Node
+
+# Based on https://github.com/jitspoe/godot-console (MIT)
+# some errors fixed, features needs to be added
+
+# TODO:
+# - autocompletion for command arguments
+# - losing input focus
+
+var enabled := true
+var enable_on_release_build := false : set = set_enable_on_release_build
+var pause_enabled := false
+
+signal console_opened
+signal console_closed
+signal console_unknown_command
+
+
+class ConsoleCommand:
+    var function : Callable
+    var arguments : PackedStringArray
+    var required : int
+    var description : String
+    func _init(in_function : Callable, in_arguments : PackedStringArray, in_required : int = 0, in_description : String = ""):
+        function = in_function
+        arguments = in_arguments
+        required = in_required
+        description = in_description
+
+
+@onready var control := Control.new()
+@onready var rich_label := RichTextLabel.new()
+@onready var line_edit := LineEdit.new()
+
+var console_commands := {}
+var console_history := []
+var console_history_index := 0
+var was_paused_already := false
+
+
+func _ready() -> void:
+    var canvas_layer := CanvasLayer.new()
+    canvas_layer.layer = 3
+    add_child(canvas_layer)
+    control.anchor_bottom = 1.0
+    control.anchor_right = 1.0
+    canvas_layer.add_child(control)
+    var style := StyleBoxFlat.new()
+    style.bg_color = Color("000000d7")
+    rich_label.selection_enabled = true
+    rich_label.context_menu_enabled = true
+    rich_label.bbcode_enabled = true
+    rich_label.scroll_following = true
+    rich_label.anchor_right = 1.0
+    rich_label.anchor_bottom = 0.5
+    rich_label.add_theme_stylebox_override("normal", style)
+    control.add_child(rich_label)
+    rich_label.append_text("Development console.\n")
+    line_edit.anchor_top = 0.5
+    line_edit.anchor_right = 1.0
+    line_edit.anchor_bottom = 0.5
+    line_edit.placeholder_text = "Enter \"help\" for instructions"
+    line_edit.focus_mode = Control.FOCUS_ALL
+    control.add_child(line_edit)
+    line_edit.text_submitted.connect(on_text_entered)
+    line_edit.text_changed.connect(on_line_edit_text_changed)
+    control.visible = false
+    process_mode = PROCESS_MODE_ALWAYS
+
+    add_command("exit", quit, 0, 0, "Exit game")
+    add_command("clear", clear, 0, 0, "Clear console")
+    add_command("delete_history", delete_history, 0, 0, "Delete console history")
+    add_command("help", commands_list, 0, 0, "Print this help")
+
+
+
+func _input(event : InputEvent) -> void:
+    if (event is InputEventKey):
+        if (event.get_physical_keycode_with_modifiers() == KEY_QUOTELEFT): # ~ key.
+            if (event.pressed):
+                toggle_console()
+            get_tree().get_root().set_input_as_handled()
+        elif (event.physical_keycode == KEY_QUOTELEFT and event.is_command_or_control_pressed()): # Toggles console size or opens big console.
+            if (event.pressed):
+                if (control.visible):
+                    toggle_size()
+                else:
+                    toggle_console()
+                    toggle_size()
+            get_tree().get_root().set_input_as_handled()
+        elif (event.get_physical_keycode_with_modifiers() == KEY_ESCAPE && control.visible): # Disable console on ESC
+            if (event.pressed):
+                toggle_console()
+                get_tree().get_root().set_input_as_handled()
+        if (control.visible and event.pressed):
+            if (event.get_physical_keycode_with_modifiers() == KEY_UP):
+                get_tree().get_root().set_input_as_handled()
+                if (console_history_index > 0):
+                    console_history_index -= 1
+                    if (console_history_index >= 0):
+                        line_edit.text = console_history[console_history_index]
+                        line_edit.caret_column = line_edit.text.length()
+                        reset_autocomplete()
+            if (event.get_physical_keycode_with_modifiers() == KEY_DOWN):
+                get_tree().get_root().set_input_as_handled()
+                if (console_history_index < console_history.size()):
+                    console_history_index += 1
+                    if (console_history_index < console_history.size()):
+                        line_edit.text = console_history[console_history_index]
+                        line_edit.caret_column = line_edit.text.length()
+                        reset_autocomplete()
+                    else:
+                        line_edit.text = ""
+                        reset_autocomplete()
+            if (event.get_physical_keycode_with_modifiers() == KEY_PAGEUP):
+                var scroll := rich_label.get_v_scroll_bar()
+                var tween := create_tween()
+                tween.tween_property(scroll, "value",  scroll.value - (scroll.page - scroll.page * 0.1), 0.1)
+                get_tree().get_root().set_input_as_handled()
+            if (event.get_physical_keycode_with_modifiers() == KEY_PAGEDOWN):
+                var scroll := rich_label.get_v_scroll_bar()
+                var tween := create_tween()
+                tween.tween_property(scroll, "value",  scroll.value + (scroll.page - scroll.page * 0.1), 0.1)
+                get_tree().get_root().set_input_as_handled()
+            if (event.get_physical_keycode_with_modifiers() == KEY_TAB):
+                autocomplete()
+                get_tree().get_root().set_input_as_handled()
+
+
+var suggestions := []
+var current_suggest := 0
+var suggesting := false
+func autocomplete() -> void:
+    if suggesting:
+        for i in range(suggestions.size()):
+            if current_suggest == i:
+                line_edit.text = str(suggestions[i])
+                line_edit.caret_column = line_edit.text.length()
+                if current_suggest == suggestions.size() - 1:
+                    current_suggest = 0
+                else:
+                    current_suggest += 1
+                return
+    else:
+        suggesting = true
+
+        var sorted_commands := []
+        for command in console_commands:
+            sorted_commands.append(str(command))
+        sorted_commands.sort()
+        sorted_commands.reverse()
+
+        var prev_index := 0
+        for command in sorted_commands:
+            if command.contains(line_edit.text):
+                var index : int = command.find(line_edit.text)
+                if index <= prev_index:
+                    suggestions.push_front(command)
+                else:
+                    suggestions.push_back(command)
+                prev_index = index
+        autocomplete()
+
+
+func reset_autocomplete() -> void:
+    suggestions.clear()
+    current_suggest = 0
+    suggesting = false
+
+
+func toggle_size() -> void:
+    if (control.anchor_bottom == 1.0):
+        control.anchor_bottom = 1.9
+    else:
+        control.anchor_bottom = 1.0
+
+
+func disable():
+    enabled = false
+    toggle_console() # Ensure hidden if opened
+
+
+func enable():
+    enabled = true
+
+
+func toggle_console() -> void:
+    set_visible(!control.visible)
+
+func set_visible(visible:bool) -> void:
+    if not control or not line_edit:
+        return
+    if (enabled):
+        control.visible = visible
+    else:
+        control.visible = false
+
+    if (control.visible):
+        was_paused_already = get_tree().paused
+        get_tree().paused = was_paused_already || pause_enabled
+        line_edit.grab_focus()
+        console_opened.emit()
+    else:
+        control.anchor_bottom = 1.0
+        scroll_to_bottom()
+        reset_autocomplete()
+        if (pause_enabled && !was_paused_already):
+            get_tree().paused = false
+        console_closed.emit()
+
+
+func is_visible():
+    return control.visible
+
+
+func scroll_to_bottom() -> void:
+    var scroll: ScrollBar = rich_label.get_v_scroll_bar()
+    scroll.value = scroll.max_value - scroll.page
+
+
+func print_line(text : String, print_godot := false) -> void:
+    if (!rich_label): # Tried to print something before the console was loaded.
+        call_deferred("print_line", text)
+    else:
+        rich_label.append_text(text)
+        rich_label.append_text("\n")
+        if (print_godot):
+            print(text)
+
+
+func parse_line_input(text : String) -> PackedStringArray:
+    var out_array : PackedStringArray
+    var first_char := true
+    var in_quotes := false
+    var escaped := false
+    var token : String
+    for c in text:
+        if (c == '\\'):
+            escaped = true
+            continue
+        elif (escaped):
+            if (c == 'n'):
+                c = '\n'
+            elif (c == 't'):
+                c = '\t'
+            elif (c == 'r'):
+                c = '\r'
+            elif (c == 'a'):
+                c = '\a'
+            elif (c == 'b'):
+                c = '\b'
+            elif (c == 'f'):
+                c = '\f'
+            escaped = false
+        elif (c == '\"'):
+            in_quotes = !in_quotes
+            continue
+        elif (c == ' ' || c == '\t'):
+            if (!in_quotes):
+                if token:
+                    out_array.push_back(token)
+                token = ""
+                continue
+        token += c
+    if token:
+        out_array.push_back(token)
+
+    return out_array
+
+
+func on_text_entered(new_text : String) -> void:
+    scroll_to_bottom()
+    reset_autocomplete()
+    line_edit.clear()
+
+
+
+    if not new_text.strip_edges().is_empty():
+        add_input_history(new_text)
+        print_line("[i]> " + new_text + "[/i]")
+        var text_split := parse_line_input(new_text)
+        var text_command := text_split[0]
+
+        if console_commands.has(text_command):
+            var arguments := text_split.slice(1)
+
+            if arguments.size() < console_commands[text_command].required:
+                print_line("[color=light_coral]	ERROR:[/color] Too few arguments! Required < %d >" % console_commands[text_command].required)
+                return
+            elif arguments.size() > console_commands[text_command].arguments.size():
+                print_line("[color=light_coral]	ERROR:[/color] Too many arguments! < %d > Max" % console_commands[text_command].arguments.size())
+                return
+
+            # Functions fail to call if passed the incorrect number of arguments, so fill out with blank strings.
+
+            console_commands[text_command].function.callv(arguments)
+        else:
+            console_unknown_command.emit(text_command)
+            print_line("[color=light_coral]	ERROR:[/color] Command not found.")
+
+    await get_tree().process_frame
+    #line_edit.edit()
+    line_edit.grab_focus()
+    line_edit.grab_click_focus()
+
+func on_line_edit_text_changed(new_text : String) -> void:
+    reset_autocomplete()
+
+
+func add_command(command_name : String, function : Callable, arguments = [], required: int = 0, description : String = "") -> void:
+    if arguments is int:
+        # Legacy call using an argument number
+        var param_array : PackedStringArray
+        for i in range(arguments):
+            param_array.append("arg_" + str(i + 1))
+        console_commands[command_name] = ConsoleCommand.new(function, param_array, required, description)
+
+    elif arguments is Array:
+        # New array argument system
+        var str_args : PackedStringArray
+        for argument in arguments:
+            str_args.append(str(argument))
+        console_commands[command_name] = ConsoleCommand.new(function, str_args, required, description)
+
+
+func remove_command(command_name : String) -> void:
+    console_commands.erase(command_name)
+
+
+func quit() -> void:
+    get_tree().quit()
+
+
+func clear() -> void:
+    rich_label.clear()
+
+
+func delete_history() -> void:
+    console_history.clear()
+    console_history_index = 0
+    DirAccess.remove_absolute("user://console_history.txt")
+
+func commands_list() -> void:
+    var commands := []
+    for command in console_commands:
+        commands.append(str(command))
+    commands.sort()
+
+    for command in commands:
+        var arguments_string := ""
+        var description : String = console_commands[command].description
+        for i in range(console_commands[command].arguments.size()):
+            if i < console_commands[command].required:
+                arguments_string += "  [color=cornflower_blue]<" + console_commands[command].arguments[i] + ">[/color]"
+            else:
+                arguments_string += "  <" + console_commands[command].arguments[i] + ">"
+        rich_label.append_text("	[color=light_green]%s[/color][color=gray]%s[/color]:   %s\n" % [command, arguments_string, description])
+    rich_label.append_text("\n")
+
+
+func add_input_history(text : String) -> void:
+    if (!console_history.size() || text != console_history.back()): # Don't add consecutive duplicates
+        console_history.append(text)
+    console_history_index = console_history.size()
+
+
+func _enter_tree() -> void:
+    var console_history_file := FileAccess.open("user://console_history.txt", FileAccess.READ)
+    if (console_history_file):
+        while (!console_history_file.eof_reached()):
+            var line := console_history_file.get_line()
+            if (line.length()):
+                add_input_history(line)
+
+
+func _exit_tree() -> void:
+    var console_history_file := FileAccess.open("user://console_history.txt", FileAccess.WRITE)
+    if (console_history_file):
+        var write_index := 0
+        var start_write_index := console_history.size() - 100 # Max lines to write
+        for line in console_history:
+            if (write_index >= start_write_index):
+                console_history_file.store_line(line)
+            write_index += 1
+
+
+func set_enable_on_release_build(enable : bool):
+    enable_on_release_build = enable
+    if (!enable_on_release_build):
+        if (!OS.is_debug_build()):
+            disable()

--- a/gdscripts/developer_console.gd
+++ b/gdscripts/developer_console.gd
@@ -1,0 +1,64 @@
+extends Node
+
+
+@export var visible:bool = false:
+    set(x):
+        if Console:
+            Console.set_visible(x)
+        visible = x
+
+
+func _ready() -> void:
+    Console.control.visible = visible
+    Console.add_command("broadcast", self.console_broadcast, ["command", "p1", "p2"], 1, "Broadcast message to all trains")
+    Console.add_command("send", self.console_send, ["train", "command", "p1", "p2"], 2, "Send message to a train")
+    Console.add_command("trains", self.console_list_trains, 0, 0, "List trains")
+    Console.add_command("commands", self.console_list_train_commands, 0, 0, "List available train commands")
+    Console.add_command("get", self.console_get_train_state, ["train", "parameter"], 1, "Get train state / parameter")
+    Console.add_command("prop", self.console_get_config_value, ["train", "property"], 2, "Get train config property")
+    Console.add_command("props", self.console_get_config_properties, ["train"], 1, "List train config properties")
+
+    TrainSystem.train_log_updated.connect(self.console_print_train_log)
+    TrainSystem.log_updated.connect(self.console_print_log)
+
+func console_get_config_value(train, property):
+    Console.print_line("%s" % TrainSystem.get_config_property(train, property))
+
+func console_get_config_properties(train):
+    var props = TrainSystem.get_supported_config_properties(train)
+    var lines = []
+    for prop in props:
+        lines.append("%s=%s" % [prop, TrainSystem.get_config_property(train, prop)])
+    Console.print_line("%s" % "\n".join(lines))
+
+func console_broadcast(command, p1=null, p2=null):
+    #Console.print_line("Broadcasting command: %s(%s, %s)" % [command, p1, p2], true)
+    TrainSystem.broadcast_command(command, p1, p2)
+
+func console_send(train, command, p1=null, p2=null):
+    TrainSystem.send_command(train, command, p1, p2)
+
+func console_list_trains():
+    Console.print_line("%s" % "\n".join(TrainSystem.get_registered_trains()))
+
+func console_list_train_commands():
+    var commands = TrainSystem.get_supported_commands()
+    commands.sort()
+    Console.print_line("%s" % "\n".join(commands))
+
+func console_print_train_log(train_id, loglevel, line):
+    console_print_log(loglevel, "%s: %s" % [train_id, line])
+
+func console_print_log(loglevel, line):
+    if loglevel >= TrainSystem.TrainLogLevel.TRAINLOGLEVEL_ERROR:
+        Console.print_line("[color=red]%s[/color]" % [line])
+    elif loglevel == TrainSystem.TrainLogLevel.TRAINLOGLEVEL_WARNING:
+        Console.print_line("[color=orange]%s[/color]" % [line])
+    else:
+        Console.print_line("%s" % [line])
+
+func console_get_train_state(train, key=null):
+    var out = TrainSystem.get_train_state(train)
+    if key:
+        out = out.get(key)
+    Console.print_line("%s" % [out])

--- a/gdscripts/developer_console.tscn
+++ b/gdscripts/developer_console.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dgm10m7u26drx"]
+
+[ext_resource type="Script" path="res://addons/libmaszyna/developer_console.gd" id="1_vako3"]
+
+[node name="DeveloperConsole" type="Node"]
+script = ExtResource("1_vako3")

--- a/gdscripts/libmaszyna.gd
+++ b/gdscripts/libmaszyna.gd
@@ -1,0 +1,9 @@
+@tool
+extends EditorPlugin
+
+func _enter_tree():
+    add_autoload_singleton("Console", "res://addons/libmaszyna/console.gd")
+
+
+func _exit_tree():
+    remove_autoload_singleton("Console")

--- a/gdscripts/plugin.cfg
+++ b/gdscripts/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="LibMaszyna"
+description=""
+author="GodotMaszyna"
+version="0.1"
+script="libmaszyna.gd"

--- a/gdscripts/powered_train_part.gd
+++ b/gdscripts/powered_train_part.gd
@@ -5,13 +5,18 @@ class_name PoweredTrainPart
 ## PoweredTrainPart will call [method _process_powered] when low power is
 ## available in a train (24V or 110V), [method _process_unpowered] otherwise.
 
+var locked = false
+
+func _enter_tree():
+    register_command("lock_power", self._on_lock_power)
+
 
 func _process_train_part(delta):
     var state = get_train_state()
     var power_avail = state.get("power24_available") or state.get("power110_available")
-    if power_avail and has_method("_process_powered"):
+    if not locked and power_avail and has_method("_process_powered"):
         call("_process_powered", delta)
-    elif not power_avail and has_method("_process_unpowered"):
+    elif (locked or not power_avail) and has_method("_process_unpowered"):
         call("_process_unpowered", delta)
     call("_process_regardless_of_power", delta)
 
@@ -29,3 +34,8 @@ func _process_unpowered(delta):
 ## Will be called regardless of low power supply
 func _process_regardless_of_power(delta):
     pass
+
+
+func _on_lock_power(p1, p2):
+    locked = true if p1 else false
+    self.log_debug("power locked: %s" % locked)

--- a/gdscripts/train_button.gd
+++ b/gdscripts/train_button.gd
@@ -70,6 +70,9 @@ func _ready():
     connect("pushed_changed", self._on_pushed_changed)
 
 func _input(event):
+    if Console.is_visible():
+        return
+
     if action:
         if monostable:
 
@@ -118,10 +121,10 @@ func _on_pushed_changed():
 
     if _controller:
         if controller_mode == ControllerMode.OnOff:
-            _controller.receive_command(controller_property, pushed)
+            _controller.send_command(controller_property, pushed)
         elif pushed and controller_mode == ControllerMode.On:
-            _controller.receive_command(controller_property, true)
+            _controller.send_command(controller_property, true)
         elif pushed and controller_mode == ControllerMode.Off:
-            _controller.receive_command(controller_property, false)
+            _controller.send_command(controller_property, false)
 
     _play_sound()

--- a/gdscripts/train_knob.gd
+++ b/gdscripts/train_knob.gd
@@ -65,18 +65,19 @@ var _value_normalized = 0.0
 
 func _process(delta):
 
-    if action_increase:
+    if action_increase and not Console.is_visible():
         if Input.is_action_pressed(action_increase, true):
-            value += step * delta
-            if _controller and command:
-                _controller.receive_command(command, value)
+            var new_value = clampf(value + step * delta, value_min, value_max)
+            if not new_value == value and _controller and command:
+                _controller.send_command(command, new_value)
+            value = new_value
 
-
-    if action_decrease:
+    if action_decrease and not Console.is_visible():
         if Input.is_action_pressed(action_decrease, true):
-            value -= step * delta
-            if _controller and command:
-                _controller.receive_command(command, value)
+            var new_value = clampf(value - step * delta, value_min, value_max)
+            if not new_value == value and _controller and command:
+                _controller.send_command(command, value)
+            value = new_value
 
     _t += delta
     if _t > 0.05:

--- a/gdscripts/train_sound_3d.gd
+++ b/gdscripts/train_sound_3d.gd
@@ -21,10 +21,8 @@ func _process(_delta):
         if state_property and _train:
             _should_play = true if _train.state.get(state_property, false) else false
             if _should_play and not playing:
-                print(self, " PLAY!")
                 play()
             elif not _should_play and playing:
-                print(self, " STOP!")
                 stop()
     if _dirty:
         _dirty = false

--- a/gdscripts/train_switch.gd
+++ b/gdscripts/train_switch.gd
@@ -94,6 +94,9 @@ func _ready():
     self.switch_position_changed.connect(self._on_switch_position_changed)
 
 func _input(event):
+    if Console.is_visible():
+        return
+
     if action_increase:
         if event.is_action_pressed(action_increase, false, true):
             switch_position += 1
@@ -157,6 +160,8 @@ func _on_switch_position_changed(previous, current):
         _sound.stream = sound_override[current-1]
     elif current < 0 and -current <= sound_override_negative.size():
         _sound.stream = sound_override_negative[-current-1]
+    elif current == 0:
+        _sound.stream = null
     else:
         _sound.stream = sound_increase_stream if current > previous else sound_decrease_stream
 
@@ -168,9 +173,9 @@ func _handle_position_change(prev, current) -> int:
     if _controller:
         var cmd = command_increase if current > prev else command_decrease
         if cmd:
-            _controller.receive_command(cmd, true)
+            _controller.send_command(cmd)
         if command_set:
-            _controller.receive_command(command_set, current)
+            _controller.send_command(command_set, current)
 
     if state_property:
         return _controller.state.get(state_property, current)

--- a/src/core/GenericTrainPart.cpp
+++ b/src/core/GenericTrainPart.cpp
@@ -16,6 +16,7 @@ namespace godot {
 
     void GenericTrainPart::_do_update_internal_mover(TMoverParameters *mover) {};
     void GenericTrainPart::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {};
+    void GenericTrainPart::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) {};
     void GenericTrainPart::_do_process_mover(TMoverParameters *mover, double delta) {};
     void GenericTrainPart::_process_train_part(const double delta) {};
     Dictionary GenericTrainPart::_get_train_part_state() {
@@ -23,6 +24,7 @@ namespace godot {
     };
     void GenericTrainPart::_process_mover(const double delta) {
         call("_process_train_part", delta);
+        // FIXME: this should not be called each frame, but only when state changes
         internal_state = call("_get_train_part_state");
         train_controller_node->get_state().merge(internal_state, true);
     };

--- a/src/core/GenericTrainPart.hpp
+++ b/src/core/GenericTrainPart.hpp
@@ -14,6 +14,7 @@ namespace godot {
         protected:
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
+            void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) override;
             void _do_process_mover(TMoverParameters *mover, double delta) override;
 
         public:

--- a/src/core/TrainController.cpp
+++ b/src/core/TrainController.cpp
@@ -6,31 +6,64 @@
 #include "../brakes/TrainBrake.hpp"
 #include "../core/TrainController.hpp"
 #include "../core/TrainPart.hpp"
+#include "../core/TrainSystem.hpp"
 #include "../engines/TrainEngine.hpp"
 #include "../systems/TrainSecuritySystem.hpp"
 
 namespace godot {
 
     const char *TrainController::MOVER_CONFIG_CHANGED_SIGNAL = "mover_config_changed";
+    const char *TrainController::MOVER_INITIALIZED_SIGNAL = "mover_initialized";
     const char *TrainController::POWER_CHANGED_SIGNAL = "power_changed";
     const char *TrainController::COMMAND_RECEIVED = "command_received";
     const char *TrainController::RADIO_TOGGLED = "radio_toggled";
     const char *TrainController::RADIO_CHANNEL_CHANGED = "radio_channel_changed";
+    const char *TrainController::CONFIG_CHANGED = "config_changed";
 
     void TrainController::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_state"), &TrainController::set_state);
         ClassDB::bind_method(D_METHOD("get_state"), &TrainController::get_state);
-        ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "state"), "set_state", "get_state");
+        ClassDB::bind_method(D_METHOD("get_config"), &TrainController::get_config);
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::DICTIONARY, "state", PROPERTY_HINT_NONE, "",
+                        PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_DEFAULT),
+                "", "get_state");
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::DICTIONARY, "config", PROPERTY_HINT_NONE, "",
+                        PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_DEFAULT),
+                "", "get_config");
 
         ClassDB::bind_method(
-                D_METHOD("receive_command", "command", "p1", "p2"), &TrainController::receive_command,
+                D_METHOD("send_command", "command", "p1", "p2"), &TrainController::send_command, DEFVAL(Variant()),
+                DEFVAL(Variant()));
+
+        ClassDB::bind_method(
+                D_METHOD("broadcast_command", "command", "p1", "p2"), &TrainController::broadcast_command,
                 DEFVAL(Variant()), DEFVAL(Variant()));
 
-        ClassDB::bind_method(D_METHOD("get_mover_state"), &TrainController::get_mover_state);
-        ClassDB::bind_method(D_METHOD("update_mover"), &TrainController::update_mover);
 
+        ClassDB::bind_method(D_METHOD("register_command", "command", "callable"), &TrainController::register_command);
         ClassDB::bind_method(
-                D_METHOD("_on_train_part_config_changed"), &TrainController::_on_train_part_config_changed);
+                D_METHOD("unregister_command", "command", "callable"), &TrainController::unregister_command);
+        ClassDB::bind_method(D_METHOD("battery", "enabled"), &TrainController::battery);
+        ClassDB::bind_method(
+                D_METHOD("main_controller_increase", "step"), &TrainController::main_controller_increase, DEFVAL(1));
+        ClassDB::bind_method(
+                D_METHOD("main_controller_decrease", "step"), &TrainController::main_controller_decrease, DEFVAL(1));
+        ClassDB::bind_method(D_METHOD("direction_increase"), &TrainController::direction_increase);
+        ClassDB::bind_method(D_METHOD("direction_decrease"), &TrainController::direction_decrease);
+        ClassDB::bind_method(D_METHOD("radio", "enabled"), &TrainController::radio);
+        ClassDB::bind_method(
+                D_METHOD("radio_channel_increase", "step"), &TrainController::radio_channel_increase, DEFVAL(1));
+        ClassDB::bind_method(
+                D_METHOD("radio_channel_decrease", "step"), &TrainController::radio_channel_decrease, DEFVAL(1));
+        ClassDB::bind_method(D_METHOD("update_mover"), &TrainController::update_mover);
+        ClassDB::bind_method(D_METHOD("update_state"), &TrainController::update_state);
+        ClassDB::bind_method(D_METHOD("update_config"), &TrainController::update_config);
+
+        ClassDB::bind_method(D_METHOD("set_train_id"), &TrainController::set_train_id);
+        ClassDB::bind_method(D_METHOD("get_train_id"), &TrainController::get_train_id);
         ClassDB::bind_method(D_METHOD("set_type_name"), &TrainController::set_type_name);
         ClassDB::bind_method(D_METHOD("get_type_name"), &TrainController::get_type_name);
         ClassDB::bind_method(D_METHOD("set_mass"), &TrainController::set_mass);
@@ -48,6 +81,7 @@ namespace godot {
         ClassDB::bind_method(D_METHOD("set_radio_channel_max"), &TrainController::set_radio_channel_min);
         ClassDB::bind_method(D_METHOD("get_radio_channel_max"), &TrainController::get_radio_channel_min);
 
+        ADD_PROPERTY(PropertyInfo(Variant::STRING, "train_id"), "set_train_id", "get_train_id");
         ADD_PROPERTY(PropertyInfo(Variant::STRING, "type_name"), "set_type_name", "get_type_name");
         ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dimensions/mass"), "set_mass", "get_mass");
         ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "power"), "set_power", "get_power");
@@ -57,9 +91,11 @@ namespace godot {
         ADD_PROPERTY(PropertyInfo(Variant::INT, "radio/channel_max"), "set_radio_channel_max", "get_radio_channel_max");
 
         ADD_SIGNAL(MethodInfo(MOVER_CONFIG_CHANGED_SIGNAL));
+        ADD_SIGNAL(MethodInfo(MOVER_INITIALIZED_SIGNAL));
         ADD_SIGNAL(MethodInfo(POWER_CHANGED_SIGNAL, PropertyInfo(Variant::BOOL, "is_powered")));
         ADD_SIGNAL(MethodInfo(RADIO_TOGGLED, PropertyInfo(Variant::BOOL, "is_enabled")));
         ADD_SIGNAL(MethodInfo(RADIO_CHANNEL_CHANGED, PropertyInfo(Variant::INT, "channel")));
+        ADD_SIGNAL(MethodInfo(CONFIG_CHANGED));
         ADD_SIGNAL(MethodInfo(
                 COMMAND_RECEIVED, PropertyInfo(Variant::STRING, "command"), PropertyInfo(Variant::NIL, "p1"),
                 PropertyInfo(Variant::NIL, "p2")));
@@ -76,6 +112,22 @@ namespace godot {
 
     TMoverParameters *TrainController::get_mover() const {
         return mover;
+    }
+
+    void TrainController::set_train_id(const String &p_train_id) {
+        train_id = p_train_id;
+    }
+
+    String TrainController::get_train_id() const {
+        if (train_id.is_empty()) {
+            String new_id = get_name().to_lower();
+            if (new_id.is_empty()) {
+                new_id = "train";
+            }
+            return new_id;
+        } else {
+            return train_id;
+        }
     }
 
     void TrainController::initialize_mover() {
@@ -109,6 +161,7 @@ namespace godot {
         mover->switch_physics(true);
 
         UtilityFunctions::print("[MaSzyna::TMoverParameters] Mover initialized successfully");
+        emit_signal(MOVER_INITIALIZED_SIGNAL);
     }
 
     void TrainController::set_type_name(const String &p_type_name) {
@@ -119,24 +172,51 @@ namespace godot {
         return type_name;
     }
 
-    void TrainController::_connect_signals_to_train_part(TrainPart *part) {
-        if (part != nullptr) {
-            const Callable _c = Callable(this, "_on_train_part_config_changed").bind(part);
-            part->connect("config_changed", _c); // Clang-Tidy: The value returned by this function should not be
-                                                 // disregarded; neglecting it may lead to errors
-        }
+    void TrainController::register_command(const String &command, const Callable &callable) {
+        TrainSystem::get_instance()->register_command(get_train_id(), command, callable);
     }
-    void TrainController::_ready() {
+
+    void TrainController::unregister_command(const String &command, const Callable &callable) {
+        TrainSystem::get_instance()->unregister_command(get_train_id(), command, callable);
+    }
+
+    void TrainController::_notification(int p_what) {
         if (Engine::get_singleton()->is_editor_hint()) {
             return;
         }
+        switch (p_what) {
+            case NOTIFICATION_ENTER_TREE:
+                TrainSystem::get_instance()->register_train(this->get_train_id(), this);
+                register_command("battery", Callable(this, "battery"));
+                register_command("main_controller_increase", Callable(this, "main_controller_increase"));
+                register_command("main_controller_decrease", Callable(this, "main_controller_decrease"));
+                register_command("direction_increase", Callable(this, "direction_increase"));
+                register_command("direction_decrease", Callable(this, "direction_decrease"));
+                register_command("radio", Callable(this, "radio"));
+                register_command("radio_channel_set", Callable(this, "radio_channel_set"));
+                register_command("radio_channel_increase", Callable(this, "radio_channel_increase"));
+                register_command("radio_channel_decrease", Callable(this, "radio_channel_decrease"));
+                break;
+            case NOTIFICATION_EXIT_TREE:
+                TrainSystem::get_instance()->unregister_train(this->get_train_id());
+                unregister_command("battery", Callable(this, "battery"));
+                unregister_command("main_controller_increase", Callable(this, "main_controller_increase"));
+                unregister_command("main_controller_decrease", Callable(this, "main_controller_decrease"));
+                unregister_command("direction_increase", Callable(this, "direction_increase"));
+                unregister_command("direction_decrease", Callable(this, "direction_decrease"));
+                unregister_command("radio", Callable(this, "radio"));
+                unregister_command("radio_channel_set", Callable(this, "radio_channel_set"));
+                unregister_command("radio_channel_increase", Callable(this, "radio_channel_increase"));
+                unregister_command("radio_channel_decrease", Callable(this, "radio_channel_decrease"));
+                break;
+            case NOTIFICATION_READY:
+                initialize_mover();
+                UtilityFunctions::print("TrainController::_ready() signals connected to train parts");
 
-        initialize_mover();
-
-        UtilityFunctions::print("TrainController::_ready() signals connected to train parts");
-
-        emit_signal(POWER_CHANGED_SIGNAL, prev_is_powered);
-        emit_signal(RADIO_CHANNEL_CHANGED, prev_radio_channel);
+                emit_signal(POWER_CHANGED_SIGNAL, prev_is_powered);
+                emit_signal(RADIO_CHANNEL_CHANGED, prev_radio_channel);
+                break;
+        }
     }
 
     void TrainController::_update_mover_config_if_dirty() {
@@ -167,6 +247,10 @@ namespace godot {
         _handle_mover_update();
     }
 
+    void TrainController::update_state() {
+        _handle_mover_update();
+    }
+
     void TrainController::_handle_mover_update() {
         state.merge(get_mover_state(), true);
 
@@ -176,7 +260,7 @@ namespace godot {
             emit_signal(POWER_CHANGED_SIGNAL, prev_is_powered);
         }
 
-        const bool new_radio_enabled = state.get("radio_enabled", false);
+        const bool new_radio_enabled = state.get("radio_enabled", false) && new_is_powered;
         if (prev_radio_enabled != new_radio_enabled) {
             prev_radio_enabled = new_radio_enabled; // FIXME: I don't like this
             emit_signal(RADIO_TOGGLED, new_radio_enabled);
@@ -213,11 +297,9 @@ namespace godot {
         mover->NominalBatteryVoltage = battery_voltage; // LoadFIZ_Light
     }
 
-    void TrainController::_on_train_part_config_changed(TrainPart *part) const {
-        if (part == nullptr) {
-            return;
-        }
-        part->update_mover();
+    void TrainController::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) const {
+        config["axles_powered_count"] = mover->NPoweredAxles;
+        config["axles_count"] = mover->NAxles;
     }
 
     double TrainController::get_battery_voltage() const {
@@ -264,10 +346,13 @@ namespace godot {
         return axle_arrangement;
     }
 
-    void TrainController::update_mover() const {
+    void TrainController::update_mover() {
         TMoverParameters *mover = get_mover();
         if (mover != nullptr) {
             _do_update_internal_mover(mover);
+            Dictionary new_config;
+            _do_fetch_config_from_mover(mover, new_config);
+            update_config(new_config);
         } else {
             UtilityFunctions::push_warning("TrainController::update_mover() failed: internal mover not initialized");
         }
@@ -309,16 +394,13 @@ namespace godot {
         internal_state["cabin_controleable"] = mover->IsCabMaster();
         internal_state["cabin_occupied"] = mover->CabOccupied;
 
-        /* FIXME: should be just a config property IMO; better to fix AxleArangement */
-        internal_state["axles_powered_count"] = mover->NPoweredAxles;
-        internal_state["axles_count"] = mover->NAxles;
-
         /* FIXME: move to TrainPower section? */
         internal_state["battery_enabled"] = mover->Battery;
         internal_state["battery_voltage"] = mover->BatteryVoltage;
 
         /* FIXME: move to TrainRadio section? */
         internal_state["radio_enabled"] = mover->Radio;
+        internal_state["radio_powered"] = mover->Radio && (mover->Power24vIsAvailable || mover->Power110vIsAvailable);
         internal_state["radio_channel"] = radio_channel;
 
         /* FIXME: move to TrainPower section */
@@ -336,46 +418,68 @@ namespace godot {
         internal_state["controller_main_position"] = mover->MainCtrlPos;
     }
 
-    void TrainController::set_state(const Dictionary &p_state) {
-        state = p_state;
+    Dictionary TrainController::get_config() const {
+        return config;
+    }
+
+    void TrainController::update_config(const Dictionary &p_config) {
+        config.merge(p_config, true);
+        emit_signal(CONFIG_CHANGED);
     }
 
     Dictionary TrainController::get_state() {
         return state;
     }
 
-    void TrainController::receive_command(const StringName &command, const Variant &p1, const Variant &p2) {
-        _on_command_received(String(command), p1, p2);
+    void TrainController::emit_command_received_signal(const String &command, const Variant &p1, const Variant &p2) {
         emit_signal(COMMAND_RECEIVED, command, p1, p2);
-        if (mover != nullptr) {
-            _handle_mover_update();
-        }
     }
 
-    void TrainController::_on_command_received(const String &command, const Variant &p1, const Variant &p2) {
-        if (!mover) {
-            return;
-        }
-        if (command == "battery") {
-            mover->BatterySwitch((bool)p1);
-        } else if (command == "main_controller_increase") {
-            UtilityFunctions::print("main_controller_increase !");
-            mover->IncMainCtrl(1);
-        } else if (command == "main_controller_decrease") {
-            UtilityFunctions::print("main_controller_decrease !");
-            mover->DecMainCtrl(1);
-        } else if (command == "forwarder_increase") {
-            mover->DirectionForward();
-        } else if (command == "forwarder_decrease") {
-            mover->DirectionBackward();
-        } else if (command == "radio_channel_increase") {
-            radio_channel = Math::clamp(radio_channel + 1, radio_channel_min, radio_channel_max);
-        } else if (command == "radio_channel_decrease") {
-            radio_channel = Math::clamp(radio_channel - 1, radio_channel_min, radio_channel_max);
-        } else if (command == "radio_channel_set") {
-            radio_channel = Math::clamp((int)p1, radio_channel_min, radio_channel_max);
-        } else if (command == "radio") {
-            mover->Radio = (bool)p1;
-        }
+    void TrainController::broadcast_command(const String &command, const Variant &p1, const Variant &p2) {
+        TrainSystem::get_instance()->broadcast_command(command, p1, p2);
+    }
+
+    void TrainController::send_command(const StringName &command, const Variant &p1, const Variant &p2) {
+        TrainSystem::get_instance()->send_command(this->get_train_id(), String(command), p1, p2);
+    }
+
+    void TrainController::battery(const bool p_enabled) {
+        mover->BatterySwitch(p_enabled);
+    }
+
+    void TrainController::main_controller_increase(const int p_step) {
+        int step = p_step > 0 ? p_step : 1;
+        mover->IncMainCtrl(step);
+    }
+
+    void TrainController::main_controller_decrease(const int p_step) {
+        int step = p_step > 0 ? p_step : 1;
+        mover->DecMainCtrl(step);
+    }
+
+    void TrainController::direction_increase() {
+        mover->DirectionForward();
+    }
+
+    void TrainController::direction_decrease() {
+        mover->DirectionBackward();
+    }
+
+    void TrainController::radio_channel_increase(const int p_step) {
+        int step = p_step > 0 ? p_step : 1;
+        radio_channel = Math::clamp(radio_channel + step, radio_channel_min, radio_channel_max);
+    }
+
+    void TrainController::radio_channel_decrease(const int p_step) {
+        int step = p_step ? p_step : 1;
+        radio_channel = Math::clamp(radio_channel - step, radio_channel_min, radio_channel_max);
+    }
+
+    void TrainController::radio_channel_set(const int p_channel) {
+        radio_channel = Math::clamp(p_channel, radio_channel_min, radio_channel_max);
+    }
+
+    void TrainController::radio(const bool p_enabled) {
+        mover->Radio = p_enabled;
     }
 } // namespace godot

--- a/src/core/TrainController.hpp
+++ b/src/core/TrainController.hpp
@@ -8,12 +8,15 @@ namespace godot {
     class TrainPart;
     class TrainEngine;
     class TrainSecuritySystem;
+    class TrainSystem;
 
 
     class TrainController final : public Node {
             GDCLASS(TrainController, Node)
         private:
             TMoverParameters *mover;
+            String train_id = "";
+
             double initial_velocity = 0.0;
             int cabin_number = 0;
             String type_name = "";
@@ -21,6 +24,7 @@ namespace godot {
             bool _dirty = false;      // Refreshes all elements
             bool _dirty_prop = false; // Refreshes only TrainController's properties
             Dictionary state;
+            Dictionary config;
             Dictionary internal_state;
 
             double battery_voltage = 0.0; // FIXME: move to TrainPower ?
@@ -38,7 +42,6 @@ namespace godot {
             String axle_arrangement = "";
 
             void _collect_train_parts(const Node *node, Vector<TrainPart *> &train_parts);
-            void _connect_signals_to_train_part(TrainPart *part);
 
         private:
             void _update_mover_config_if_dirty();
@@ -49,32 +52,51 @@ namespace godot {
              * for creating Train nodes. Pointer to `mover` and reference to `state` should stay "as is",
              * because the mover initialization and state sharing routines can be changed in the future. */
 
+            Dictionary get_mover_state();
             // TrainController mozna bedzie rozszerzac klasami pochodnymi i przeslaniac metody
             void _do_update_internal_mover(TMoverParameters *mover) const;
+            void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) const;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state);
             void _process_mover(double delta);
 
 
         public:
             static const char *MOVER_CONFIG_CHANGED_SIGNAL;
+            static const char *MOVER_INITIALIZED_SIGNAL;
             static const char *POWER_CHANGED_SIGNAL;
             static const char *COMMAND_RECEIVED;
             static const char *RADIO_TOGGLED;
             static const char *RADIO_CHANNEL_CHANGED;
+            static const char *CONFIG_CHANGED;
 
+            Dictionary get_config() const;
+            void update_config(const Dictionary &p_config);
+            void set_config_property(String &key, Variant &p_value);
             void _process(double delta) override;
-            void _ready() override;
-            Dictionary get_mover_state();
-            void
-            receive_command(const StringName &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
-            void
-            _on_command_received(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
-            void update_mover() const;
-            void _on_train_part_config_changed(TrainPart *part) const;
+            void _notification(int p_what);
+            void send_command(const StringName &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
+            void battery(const bool p_enabled);
+            void main_controller_increase(const int p_step = 1);
+            void main_controller_decrease(const int p_step = 1);
+            void direction_increase();
+            void direction_decrease();
+            void radio(const bool p_enabled);
+            void radio_channel_set(const int p_channel);
+            void radio_channel_increase(const int step = 1);
+            void radio_channel_decrease(const int step = 1);
+            void emit_command_received_signal(
+                    const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
+            void broadcast_command(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
+            void register_command(const String &command, const Callable &callable);
+            void unregister_command(const String &command, const Callable &callable);
+            void update_state();
+            void update_mover();
 
             TMoverParameters *get_mover() const;
             static void _bind_methods();
 
+            String get_train_id() const;
+            void set_train_id(const String &train_id);
             String get_type_name() const;
             void set_type_name(const String &type_name);
             void set_battery_voltage(const double p_value);

--- a/src/core/TrainLogLevel.hpp
+++ b/src/core/TrainLogLevel.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+namespace godot {}

--- a/src/core/TrainPart.cpp
+++ b/src/core/TrainPart.cpp
@@ -1,15 +1,28 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
+#include "./TrainSystem.hpp"
 #include "TrainController.hpp"
 #include "TrainPart.hpp"
 
 namespace godot {
     void TrainPart::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("on_command_received"), &TrainPart::on_command_received);
         ClassDB::bind_method(D_METHOD("emit_config_changed_signal"), &TrainPart::emit_config_changed_signal);
+        ClassDB::bind_method(D_METHOD("register_command", "command", "callable"), &TrainPart::register_command);
+        ClassDB::bind_method(D_METHOD("unregister_command", "command", "callable"), &TrainPart::unregister_command);
         ClassDB::bind_method(D_METHOD("update_mover"), &TrainPart::update_mover);
         ClassDB::bind_method(D_METHOD("get_mover_state"), &TrainPart::get_mover_state);
+        ClassDB::bind_method(
+                D_METHOD("send_command", "command", "p1", "p2"), &TrainPart::send_command, DEFVAL(Variant()),
+                DEFVAL(Variant()));
+        ClassDB::bind_method(
+                D_METHOD("broadcast_command", "command", "p1", "p2"), &TrainPart::broadcast_command, DEFVAL(Variant()),
+                DEFVAL(Variant()));
+        ClassDB::bind_method(D_METHOD("log", "loglevel", "line"), &TrainPart::log);
+        ClassDB::bind_method(D_METHOD("log_debug", "line"), &TrainPart::log_debug);
+        ClassDB::bind_method(D_METHOD("log_info", "line"), &TrainPart::log_info);
+        ClassDB::bind_method(D_METHOD("log_warning", "line"), &TrainPart::log_warning);
+        ClassDB::bind_method(D_METHOD("log_error", "line"), &TrainPart::log_error);
 
         ClassDB::bind_method(D_METHOD("set_enabled"), &TrainPart::set_enabled);
         ClassDB::bind_method(D_METHOD("get_enabled"), &TrainPart::get_enabled);
@@ -22,63 +35,89 @@ namespace godot {
     }
 
     TrainPart::TrainPart() = default;
+    void TrainPart::_register_commands() {};
+    void TrainPart::_unregister_commands() {};
 
-    void TrainPart::_ready() {
-        /* Dear Lord, prevent it from running in the editor. Thanks~ UwU */
+    TMoverParameters *TrainPart::get_mover() {
+        if (train_controller_node != nullptr) {
+            return train_controller_node->get_mover();
+        } else {
+            return nullptr;
+        }
+    }
+
+    void TrainPart::_notification(int p_what) {
         if (Engine::get_singleton()->is_editor_hint()) {
             return;
         }
-        if (train_controller_node != nullptr) {
-            train_controller_node->connect(TrainController::COMMAND_RECEIVED, Callable(this, "on_command_received"));
+        switch (p_what) {
+            case NOTIFICATION_ENTER_TREE: {
+                Node *p = get_parent();
+                while (p != nullptr) {
+                    train_controller_node = Object::cast_to<TrainController>(p);
+                    if (train_controller_node != nullptr) {
+                        break;
+                    }
+                    p = p->get_parent();
+                }
+                if (train_controller_node != nullptr) {
+                    train_controller_node->connect(
+                            TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
+                }
+                if (enabled) {
+                    _register_commands();
+                    _commands_registered = true;
+                }
+            } break;
+            case NOTIFICATION_EXIT_TREE: {
+                if (get_enabled()) {
+                    _unregister_commands();
+                    _commands_registered = false;
+                }
+                if (train_controller_node != nullptr) {
+                    train_controller_node->disconnect(
+                            TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
+                }
+                train_controller_node = nullptr;
+            } break;
         }
-        _dirty = true;
+    }
+
+    void TrainPart::log(const TrainSystem::TrainLogLevel level, const String &line) {
+        if (train_controller_node != nullptr) {
+            TrainSystem::get_instance()->log(train_controller_node->get_train_id(), level, line);
+        }
+    }
+    void TrainPart::log_debug(const String &line) {
+        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_DEBUG, line);
+    }
+
+    void TrainPart::log_info(const String &line) {
+        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_INFO, line);
+    }
+
+    void TrainPart::log_warning(const String &line) {
+        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_WARNING, line);
+    }
+
+    void TrainPart::log_error(const String &line) {
+        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_ERROR, line);
+    }
+
+    void TrainPart::register_command(const String &command, const Callable &callback) {
+        TrainSystem::get_instance()->register_command(train_controller_node->get_train_id(), command, callback);
+    }
+
+    void TrainPart::unregister_command(const String &command, const Callable &callback) {
+        TrainSystem::get_instance()->unregister_command(train_controller_node->get_train_id(), command, callback);
     }
 
     void TrainPart::emit_config_changed_signal() {
         emit_signal("config_changed");
     }
 
-    void TrainPart::_enter_tree() {
-        if (Engine::get_singleton()->is_editor_hint()) {
-            return;
-        }
-        Node *p = get_parent();
-        while (p != nullptr) {
-            train_controller_node = Object::cast_to<TrainController>(p);
-            if (train_controller_node != nullptr) {
-                break;
-            }
-            p = p->get_parent();
-        }
-        if (train_controller_node != nullptr) {
-            train_controller_node->connect(
-                    TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
-        }
-    }
-
-    void TrainPart::_exit_tree() {
-        if (Engine::get_singleton()->is_editor_hint()) {
-            return;
-        }
-        if (train_controller_node != nullptr) {
-            train_controller_node->disconnect(
-                    TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
-        }
-        train_controller_node = nullptr;
-    }
-
     void TrainPart::_process(double delta) {
         if (Engine::get_singleton()->is_editor_hint()) {
-            return;
-        }
-
-        if (!get_enabled()) {
-            if(enabled_changed) {
-                enabled_changed = false;
-                emit_signal("enable_changed", false);
-                emit_signal("train_part_disabled");
-            }
-
             return;
         }
 
@@ -88,10 +127,21 @@ namespace godot {
             _dirty = false;
         }
 
-        _process_mover(delta);
+        if (enabled) {
+            _process_mover(delta);
+        }
 
-        if(enabled_changed) {
+        if (enabled_changed) {
             enabled_changed = false;
+            if (enabled && !_commands_registered) {
+                log_debug("Registering commands for train part " + get_name());
+                _register_commands();
+                _commands_registered = true;
+            } else if (!enabled && _commands_registered) {
+                log_debug("Unregistering commands for train part " + get_name());
+                _unregister_commands();
+                _commands_registered = false;
+            }
             emit_signal("enable_changed", enabled);
             emit_signal(enabled ? "train_part_enabled" : "train_part_disabled");
         }
@@ -107,11 +157,19 @@ namespace godot {
         }
     }
 
+    void TrainPart::_do_process_mover(TMoverParameters *mover, double delta) {}
+
+    void TrainPart::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) {};
+    void TrainPart::_do_update_internal_mover(TMoverParameters *mover) {};
+
     void TrainPart::update_mover() {
         if (train_controller_node != nullptr) {
             TMoverParameters *mover = train_controller_node->get_mover();
             if (mover != nullptr) {
                 _do_update_internal_mover(mover);
+                Dictionary new_config;
+                _do_fetch_config_from_mover(mover, new_config);
+                train_controller_node->update_config(new_config);
             } else {
                 UtilityFunctions::push_warning("TrainPart::update_mover() failed: internal mover not initialized");
             }
@@ -121,7 +179,7 @@ namespace godot {
     }
 
     Dictionary TrainPart::get_mover_state() {
-        if(!get_enabled()) {
+        if (!get_enabled()) {
             return state;
         }
         if (train_controller_node != nullptr) {
@@ -147,11 +205,14 @@ namespace godot {
         return enabled;
     }
 
-    void TrainPart::on_command_received(const String &command, const Variant &p1, const Variant &p2) {
-        _on_command_received(command, p1, p2);
-        update_mover();
+    void TrainPart::send_command(const String &command, const Variant &p1, const Variant &p2) {
+        if (train_controller_node != nullptr) {
+            TrainSystem::get_instance()->send_command(train_controller_node->get_train_id(), command, p1, p2);
+        }
     }
-    
-    void TrainPart::_on_command_received(const String &command, const Variant &p1, const Variant &p2) {
+
+    void TrainPart::broadcast_command(const String &command, const Variant &p1, const Variant &p2) {
+        TrainSystem::get_instance()->broadcast_command(command, p1, p2);
     }
+
 } // namespace godot

--- a/src/core/TrainSystem.cpp
+++ b/src/core/TrainSystem.cpp
@@ -1,0 +1,282 @@
+#include "../core/TrainController.hpp"
+#include "./TrainSystem.hpp"
+
+namespace godot {
+    void TrainSystem::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("register_train", "train_id", "train"), &TrainSystem::register_train);
+        ClassDB::bind_method(D_METHOD("unregister_train", "train_id"), &TrainSystem::unregister_train);
+        ClassDB::bind_method(D_METHOD("get_train_count"), &TrainSystem::get_train_count);
+        ClassDB::bind_method(
+                D_METHOD("get_config_property", "train_id", "property_name"), &TrainSystem::get_config_property);
+        ClassDB::bind_method(
+                D_METHOD("get_all_config_properties", "train_id"), &TrainSystem::get_all_config_properties);
+        ClassDB::bind_method(
+                D_METHOD("get_supported_config_properties", "train_id"), &TrainSystem::get_supported_config_properties);
+        ClassDB::bind_method(
+                D_METHOD("send_command", "train_id", "command", "p1", "p2"), &TrainSystem::send_command,
+                DEFVAL(Variant()), DEFVAL(Variant()));
+        ClassDB::bind_method(
+                D_METHOD("broadcast_command", "command", "p1", "p2"), &TrainSystem::broadcast_command,
+                DEFVAL(Variant()), DEFVAL(Variant()));
+        ClassDB::bind_method(D_METHOD("is_command_supported", "command"), &TrainSystem::is_command_supported);
+        ClassDB::bind_method(D_METHOD("get_supported_commands"), &TrainSystem::get_supported_commands);
+        ClassDB::bind_method(D_METHOD("get_registered_trains"), &TrainSystem::get_registered_trains);
+        ClassDB::bind_method(
+                D_METHOD("register_command", "train_id", "command", "callable"), &TrainSystem::register_command);
+        ClassDB::bind_method(
+                D_METHOD("unregister_command", "train_id", "command", "callable"), &TrainSystem::unregister_command);
+        ClassDB::bind_method(D_METHOD("get_train_state", "train_id"), &TrainSystem::get_train_state);
+        ClassDB::bind_method(D_METHOD("log", "train_id", "loglevel", "line"), &TrainSystem::log);
+        ClassDB::bind_method(D_METHOD("global_log", "loglevel", "line"), &TrainSystem::global_log);
+        ADD_SIGNAL(MethodInfo(
+                "train_log_updated", PropertyInfo(Variant::STRING, "train"), PropertyInfo(Variant::INT, "loglevel"),
+                PropertyInfo(Variant::STRING, "line")));
+        ADD_SIGNAL(MethodInfo(
+                "log_updated", PropertyInfo(Variant::INT, "loglevel"), PropertyInfo(Variant::STRING, "line")));
+        BIND_ENUM_CONSTANT(TRAINLOGLEVEL_DEBUG);
+        BIND_ENUM_CONSTANT(TRAINLOGLEVEL_INFO);
+        BIND_ENUM_CONSTANT(TRAINLOGLEVEL_WARNING);
+        BIND_ENUM_CONSTANT(TRAINLOGLEVEL_ERROR);
+    }
+
+    TrainSystem::TrainSystem() {}
+
+    int TrainSystem::get_train_count() const {
+        return trains.size();
+    }
+
+    bool TrainSystem::is_train_registered(const String &train_id) const {
+        auto it = trains.find(train_id);
+
+        if (it == trains.end()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    TrainController *TrainSystem::get_train(const String &train_id) {
+        auto it = trains.find(train_id);
+
+        if (it == trains.end()) {
+            return nullptr;
+        } else {
+            return it->second;
+        }
+    }
+
+    Dictionary TrainSystem::get_train_state(const String &train_id) {
+        TrainController *train = get_train(train_id);
+
+        if (train == nullptr) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            Dictionary empty;
+            return empty;
+        }
+        return train->get_state();
+    }
+
+    Array TrainSystem::get_supported_config_properties(const String &train_id) {
+        return get_all_config_properties(train_id).keys();
+    }
+
+    Dictionary TrainSystem::get_all_config_properties(const String &train_id) {
+        auto it = trains.find(train_id);
+
+        if (it == trains.end()) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered in");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            return Dictionary();
+        }
+        TrainController *train = it->second;
+        return train->get_config();
+    }
+
+    Variant TrainSystem::get_config_property(const String &train_id, const String &property_name) {
+        Dictionary props = get_all_config_properties(train_id);
+        return props.get(property_name, "");
+    }
+
+    void TrainSystem::log(const String &train_id, const TrainLogLevel level, const String &line) {
+        emit_signal("train_log_updated", train_id, level, line);
+    }
+
+    void TrainSystem::global_log(const TrainLogLevel level, const String &line) {
+        // FIXME: move to LogSystem???
+        emit_signal("log_updated", level, line);
+    }
+
+    void TrainSystem::register_train(const String &train_id, TrainController *train) {
+        if (is_train_registered(train_id)) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is already registered!");
+            UtilityFunctions::push_error("Train is already registered: ", train_id);
+        } else {
+            trains[train_id] = train;
+        }
+    }
+
+    void TrainSystem::register_command(const String &train_id, const String &command, const Callable &callback) {
+        if (!is_train_registered(train_id)) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered in");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            return;
+        }
+
+        if (!commands.has(command)) {
+            Dictionary _trains;
+            commands[command] = _trains;
+        }
+
+
+        if ((static_cast<Dictionary>(commands[command])).has(train_id)) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Command is already registered: " + command);
+            UtilityFunctions::push_error("Command ", command, " is already registered for train ", train_id);
+            return;
+        }
+
+        Dictionary _trains = commands[command];
+        _trains[train_id] = callback;
+    }
+
+    void TrainSystem::unregister_command(const String &train_id, const String &command, const Callable &callback) {
+        if (!is_train_registered(train_id)) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            return;
+        }
+
+        if (!is_command_supported(command)) {
+            global_log(TrainLogLevel::TRAINLOGLEVEL_ERROR, "Cannot unregister unknown command: " + command);
+            UtilityFunctions::push_error("Unknown command: ", command);
+        }
+
+        if (commands.has(command)) {
+            Dictionary _trains = static_cast<Dictionary>(commands[command]);
+            if (!_trains.has(train_id)) {
+                log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Command is not registered: " + command);
+                UtilityFunctions::push_error("Command ", command, " is not registered for train ", train_id);
+                return;
+            }
+            _trains.erase(train_id);
+            if (_trains.size() == 0) {
+                commands.erase(command);
+            }
+        }
+    }
+
+    void TrainSystem::unregister_train(const String &train_id) {
+        if (!is_train_registered(train_id)) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            return;
+        }
+
+        Array command_keys = static_cast<Array>(commands.keys());
+        Array commands_to_remove;
+
+        for (int i = 0; i < command_keys.size(); i++) {
+            String command = command_keys[i];
+            Dictionary _trains = commands[command];
+            if (_trains.has(train_id)) {
+                _trains.erase(train_id);
+            }
+            if (_trains.size() == 0) {
+                commands_to_remove.append(command);
+            }
+        }
+
+        for (int i = 0; i < commands_to_remove.size(); i++) {
+            commands.erase(commands_to_remove[i]);
+        }
+
+        trains.erase(train_id);
+    }
+
+    bool TrainSystem::is_command_supported(const String &command) {
+        return commands.has(command);
+    }
+
+    Array TrainSystem::get_supported_commands() {
+        return commands.keys();
+    }
+
+    Array TrainSystem::get_registered_trains() {
+        Array train_names;
+        for (const auto &pair: trains) {
+            train_names.append(pair.first);
+        }
+        return train_names;
+    }
+
+    void
+    TrainSystem::send_command(const String &train_id, const String &command, const Variant &p1, const Variant &p2) {
+        auto it = trains.find(train_id);
+
+        if (it == trains.end()) {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Train is not registered");
+            UtilityFunctions::push_error("Train is not registered: ", train_id);
+            return;
+        }
+        TrainController *train = it->second;
+        if (is_command_supported(command)) {
+
+            Dictionary _trains = static_cast<Dictionary>(commands[command]);
+
+            if (!_trains.has(train_id)) {
+                log(train_id, TrainLogLevel::TRAINLOGLEVEL_WARNING, "train cannot handle command: " + command);
+                UtilityFunctions::push_warning("Train \"", train_id, "\" cannot handle command \"", command, "\"");
+                return;
+            }
+
+            Callable c = _trains[train_id];
+
+            if (c.is_valid()) {
+                Array args;
+                int arg_required = 0;
+                if (p1.get_type() != Variant::NIL) {
+                    arg_required++;
+                }
+                if (p2.get_type() != Variant::NIL) {
+                    arg_required++;
+                }
+                int argc = c.get_argument_count();
+                if (argc > 0) {
+                    args.append(p1);
+                }
+                if (argc > 1) {
+                    args.append(p2);
+                }
+                c.callv(args);
+#if DEBUG_MODE
+                log(train_id, TrainLogLevel::TRAINLOGLEVEL_DEBUG,
+                    "received command " + command + "(" + String(", ").join(args) + ")");
+                if (arg_required != argc) {
+                    UtilityFunctions::push_warning(
+                            "Method ", c.get_object(), "::", c.get_method(), " should handle ", arg_required,
+                            " arguments, but it has ", argc);
+                }
+#endif
+            } else {
+                UtilityFunctions::push_error("Callable ", c, " is invalid");
+            }
+        } else {
+            log(train_id, TrainLogLevel::TRAINLOGLEVEL_ERROR, "Unknown command: " + command);
+            ERR_PRINT("Unknown command: " + command);
+        }
+
+        train->update_state();
+        train->emit_command_received_signal(command, p1, p2);
+    }
+
+    void TrainSystem::broadcast_command(const String &command, const Variant &p1, const Variant &p2) {
+        if (!is_command_supported(command)) {
+            global_log(TrainLogLevel::TRAINLOGLEVEL_ERROR, "Unknown command: " + command);
+            ERR_PRINT("Unknown command: " + command);
+            return;
+        }
+        for (auto &[train_id, train]: trains) {
+            send_command(train_id, command, p1, p2);
+        }
+    }
+} // namespace godot

--- a/src/core/TrainSystem.hpp
+++ b/src/core/TrainSystem.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <map>
+#include "./TrainLogLevel.hpp"
+
+namespace godot {
+
+    class TrainController;
+
+    class TrainSystem : public RefCounted {
+            GDCLASS(TrainSystem, RefCounted);
+
+        private:
+            std::map<String, TrainController *> trains;
+            Dictionary commands;
+
+        public:
+            inline static TrainSystem *get_instance() {
+                return dynamic_cast<TrainSystem *>(godot::Engine::get_singleton()->get_singleton("TrainSystem"));
+            }
+
+            enum TrainLogLevel {
+                TRAINLOGLEVEL_DEBUG = 0,
+                TRAINLOGLEVEL_INFO,
+                TRAINLOGLEVEL_WARNING,
+                TRAINLOGLEVEL_ERROR,
+            };
+            TrainSystem();
+            ~TrainSystem() override = default;
+
+            void register_train(const String &train_id, TrainController *train);
+            void unregister_train(const String &train_id);
+            bool is_train_registered(const String &train_id) const;
+            TrainController *get_train(const String &train_id);
+            int get_train_count() const;
+
+            Variant get_config_property(const String &train_id, const String &property);
+            Dictionary get_all_config_properties(const String &train_id);
+            Array get_supported_config_properties(const String &train_id);
+
+            void register_command(const String &train_id, const String &command, const Callable &callback);
+            void unregister_command(const String &train_id, const String &command, const Callable &callback);
+            Array get_supported_commands();
+            Array get_registered_trains();
+            void send_command(
+                    const String &train_id, const String &command, const Variant &p1 = Variant(),
+                    const Variant &p2 = Variant());
+            void broadcast_command(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
+            bool is_command_supported(const String &command);
+
+            void log(const String &train_id, const TrainLogLevel level, const String &line);
+
+            // FIXME: move to LogSystem???
+            void global_log(const TrainLogLevel level, const String &line);
+
+            Dictionary get_train_state(const String &train_id);
+
+        protected:
+            static void _bind_methods();
+    };
+} // namespace godot
+VARIANT_ENUM_CAST(TrainSystem::TrainLogLevel)

--- a/src/engines/TrainDieselEngine.hpp
+++ b/src/engines/TrainDieselEngine.hpp
@@ -20,7 +20,9 @@ namespace godot {
             TEngineType get_engine_type() override;
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
-            void _do_process_mover(TMoverParameters *mover, const double delta) override;
+            void _register_commands() override;
+            void _unregister_commands() override;
+
 
         public:
             double get_oil_min_pressure() const;
@@ -35,7 +37,8 @@ namespace godot {
             TypedArray<Array> get_wwlist();
             void set_wwlist(const TypedArray<Array> p_wwlist);
 
-            void _on_command_received(const String &command, const Variant &p1, const Variant &p2) override;
+            void oil_pump(const bool p_enabled);
+            void fuel_pump(const bool p_enabled);
 
             TrainDieselEngine();
             ~TrainDieselEngine() override = default;

--- a/src/engines/TrainElectricEngine.cpp
+++ b/src/engines/TrainElectricEngine.cpp
@@ -8,14 +8,6 @@ namespace godot {
 
     void TrainElectricEngine::_bind_methods() {
 
-        ClassDB::bind_method(
-                D_METHOD("set_converter_switch_pressed"), &TrainElectricEngine::set_converter_switch_pressed);
-        ClassDB::bind_method(
-                D_METHOD("get_converter_switch_pressed"), &TrainElectricEngine::get_converter_switch_pressed);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "switches/converter"), "set_converter_switch_pressed",
-                "get_converter_switch_pressed");
-
         ClassDB::bind_method(D_METHOD("set_engine_power_source"), &TrainElectricEngine::set_engine_power_source);
         ClassDB::bind_method(D_METHOD("get_engine_power_source"), &TrainElectricEngine::get_engine_power_source);
         ADD_PROPERTY(
@@ -136,6 +128,9 @@ namespace godot {
                 PropertyInfo(Variant::FLOAT, "power/power_cable/steam_pressure"), "set_power_cable_steam_pressure",
                 "get_power_cable_steam_pressure");
 
+        ClassDB::bind_method(D_METHOD("compressor", "enabled"), &TrainElectricEngine::compressor);
+        ClassDB::bind_method(D_METHOD("converter", "enabled"), &TrainElectricEngine::converter);
+
         BIND_ENUM_CONSTANT(POWER_SOURCE_NOT_DEFINED);
         BIND_ENUM_CONSTANT(POWER_SOURCE_INTERNAL);
         BIND_ENUM_CONSTANT(POWER_SOURCE_TRANSDUCER);
@@ -226,28 +221,30 @@ namespace godot {
         }
     }
 
-    void TrainElectricEngine::_do_process_mover(TMoverParameters *mover, const double delta) {
-        TrainEngine::_do_process_mover(mover, delta);
-
-        mover->ConverterSwitch(converter_switch_pressed);
-        mover->CompressorSwitch(compressor_switch_pressed);
+    void TrainElectricEngine::converter(const bool p_enabled) {
+        TMoverParameters *mover = get_mover();
+        ASSERT_MOVER(mover);
+        mover->ConverterSwitch(p_enabled);
     }
 
-    void TrainElectricEngine::set_converter_switch_pressed(const bool p_state) {
-        converter_switch_pressed = p_state;
+    void TrainElectricEngine::compressor(const bool p_enabled) {
+        TMoverParameters *mover = get_mover();
+        ASSERT_MOVER(mover);
+        mover->CompressorSwitch(p_enabled);
     }
 
-    bool TrainElectricEngine::get_converter_switch_pressed() const {
-        return converter_switch_pressed;
+    void TrainElectricEngine::_register_commands() {
+        TrainEngine::_register_commands();
+        register_command("converter", Callable(this, "converter"));
+        register_command("compressor", Callable(this, "compressor"));
     }
 
-    void TrainElectricEngine::set_compressor_switch_pressed(const bool p_state) {
-        compressor_switch_pressed = p_state;
+    void TrainElectricEngine::_unregister_commands() {
+        TrainEngine::_unregister_commands();
+        unregister_command("converter", Callable(this, "converter"));
+        unregister_command("compressor", Callable(this, "compressor"));
     }
 
-    bool TrainElectricEngine::get_compressor_switch_pressed() const {
-        return compressor_switch_pressed;
-    }
 
     void TrainElectricEngine::set_engine_power_source(const TrainPowerSource p_source) {
         power_source = p_source;

--- a/src/engines/TrainElectricEngine.hpp
+++ b/src/engines/TrainElectricEngine.hpp
@@ -29,8 +29,6 @@ namespace godot {
             };
 
             static void _bind_methods();
-            bool converter_switch_pressed = false;
-            bool compressor_switch_pressed = false;
             TrainPowerSource power_source = static_cast<TrainPowerSource>(static_cast<int>(TPowerSource::NotDefined));
             int collectors_no = 0;
             float max_voltage = 0;
@@ -78,14 +76,8 @@ namespace godot {
         protected:
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
-            void _do_process_mover(TMoverParameters *mover, const double delta) override;
 
         public:
-            void set_converter_switch_pressed(bool p_state);
-            bool get_converter_switch_pressed() const;
-
-            void set_compressor_switch_pressed(bool p_state);
-            bool get_compressor_switch_pressed() const;
             void set_engine_power_source(TrainPowerSource p_source);
             TrainPowerSource get_engine_power_source() const;
             int get_number_of_collectors() const;
@@ -121,6 +113,11 @@ namespace godot {
             TrainPowerType get_power_cable_power_source() const;
             void set_power_cable_steam_pressure(float p_pressure);
             float get_power_cable_steam_pressure() const;
+
+            void compressor(const bool p_enabled);
+            void converter(const bool p_enabled);
+            void _register_commands() override;
+            void _unregister_commands() override;
     };
 } // namespace godot
 VARIANT_ENUM_CAST(TrainElectricEngine::TrainPowerSource);

--- a/src/engines/TrainEngine.hpp
+++ b/src/engines/TrainEngine.hpp
@@ -16,12 +16,14 @@ namespace godot {
             virtual TEngineType get_engine_type() = 0;
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
-            void _do_process_mover(TMoverParameters *mover, double delta) override;
+            void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) override;
+            void _register_commands() override;
+            void _unregister_commands() override;
 
         public:
             TypedArray<Dictionary> get_motor_param_table();
             void set_motor_param_table(const TypedArray<Dictionary> p_wwlist);
-            void _on_command_received(const String &command, const Variant &p1, const Variant &p2) override;
+            void main_switch(const bool p_enabled);
 
             TrainEngine();
             ~TrainEngine() override = default;

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,6 +1,7 @@
 #include "register_types.h"
 
 #include <gdextension_interface.h>
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
 
@@ -8,6 +9,7 @@
 #include "core/GenericTrainPart.hpp"
 #include "core/TrainController.hpp"
 #include "core/TrainPart.hpp"
+#include "core/TrainSystem.hpp"
 #include "engines/TrainDieselElectricEngine.hpp"
 #include "engines/TrainDieselEngine.hpp"
 #include "engines/TrainElectricEngine.hpp"
@@ -16,6 +18,8 @@
 #include "systems/TrainSecuritySystem.hpp"
 
 using namespace godot;
+
+TrainSystem *train_system_singleton = nullptr;
 
 void initialize_libmaszyna_module(ModuleInitializationLevel p_level) {
     if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
@@ -33,12 +37,22 @@ void initialize_libmaszyna_module(ModuleInitializationLevel p_level) {
         GDREGISTER_CLASS(TrainElectricSeriesEngine);
         GDREGISTER_CLASS(TrainController);
         GDREGISTER_CLASS(TrainSecuritySystem);
+        GDREGISTER_CLASS(TrainSystem);
+
+        train_system_singleton = memnew(TrainSystem);
+        Engine::get_singleton()->register_singleton("TrainSystem", train_system_singleton);
     }
 }
 
 void uninitialize_libmaszyna_module(ModuleInitializationLevel p_level) {
     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
         return;
+    }
+
+    if (train_system_singleton) {
+        Engine::get_singleton()->unregister_singleton("TrainSystem");
+        // memdelete(train_system_singleton);
+        // train_system_singleton = nullptr;
     }
 }
 

--- a/src/systems/TrainSecuritySystem.hpp
+++ b/src/systems/TrainSecuritySystem.hpp
@@ -14,7 +14,8 @@ namespace godot {
         protected:
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
-            void _do_process_mover(TMoverParameters *mover, double delta) override;
+            void _register_commands() override;
+            void _unregister_commands() override;
 
         public:
             enum EmergencyBrakeWarningSignal {
@@ -43,7 +44,8 @@ namespace godot {
             double ca_max_hold_time = 0.0;              // MaxHoldTime -> SecuritySystem->MaxHoldTime
 
         public:
-            void _on_command_received(const String &command, const Variant &p1, const Variant &p2) override;
+            void security_acknowledge(const bool p_enabled);
+
             // Getters
             bool get_aware_system_active() const;
             bool get_aware_system_cabsignal() const;


### PR DESCRIPTION
This PR introduces flexible command system, which makes commands handling less error prone, introduces unified interface, and gives possibility to inspect commands registry. Commands can be broadcasted or sent to a specified train. Trains can handle different set of commands. The system is extensible - by implementing custom `GenericTrainPart` (GDScript) or `TrainPart` (C++) developer can register own commands also in mod packs.

By using this system together with a composition of behavioral nodes, anyone can create their own trains / other vehicles.

**NOTE:** The Commands API layer is for internal communication only. It should not be used as (nor mixed with) a cabin commands system. 

----

* Adds developer console (`Console` singleton)
* Adds commands registry and dispatcher (`TrainSystem` singleton)
* Adds config properties for trains (`TrainSystem` singleton, `TrainController.config`)
* Removes `TrainPart._on_command_received` and `TrainController._on_command_received`
* Implements commands handling in a separate callbacks
* Cleans interface of `TrainPart` and `TrainController`
* Adds shortcuts (proxies) to the `TrainSystem` in `TrainController` and `TrainPart`
* Adds unique train identifiers (`TrainController.train_id`)
* Adds `brake_level_set_position` command
* Fixes brakes handling
* Updates documentation

----

![image](https://github.com/user-attachments/assets/da0cdefd-9bee-4ad3-ad87-79483c1b9f52)

![image](https://github.com/user-attachments/assets/a3441bb9-4512-4874-b0e6-962c3c32db94)
