### PR TITLE
Add LogSystem

### DIFF
--- a/addons/libmaszyna/developer_console.gd
+++ b/addons/libmaszyna/developer_console.gd
@@ -18,8 +18,7 @@ func _ready() -> void:
     Console.add_command("prop", self.console_get_config_value, ["train", "property"], 2, "Get train config property")
     Console.add_command("props", self.console_get_config_properties, ["train"], 1, "List train config properties")
 
-    TrainSystem.train_log_updated.connect(self.console_print_train_log)
-    TrainSystem.log_updated.connect(self.console_print_log)
+    LogSystem.log_updated.connect(self.console_print_log)
 
 func console_get_config_value(train, property):
     Console.print_line("%s" % TrainSystem.get_config_property(train, property))
@@ -46,13 +45,10 @@ func console_list_train_commands():
     commands.sort()
     Console.print_line("%s" % "\n".join(commands))
 
-func console_print_train_log(train_id, loglevel, line):
-    console_print_log(loglevel, "%s: %s" % [train_id, line])
-
 func console_print_log(loglevel, line):
-    if loglevel >= TrainSystem.TrainLogLevel.TRAINLOGLEVEL_ERROR:
+    if loglevel >= LogSystem.LogLevel.LOGLEVEL_ERROR:
         Console.print_line("[color=red]%s[/color]" % [line])
-    elif loglevel == TrainSystem.TrainLogLevel.TRAINLOGLEVEL_WARNING:
+    elif loglevel == LogSystem.LogLevel.LOGLEVEL_WARNING:
         Console.print_line("[color=orange]%s[/color]" % [line])
     else:
         Console.print_line("%s" % [line])

--- a/src/core/LogSystem.cpp
+++ b/src/core/LogSystem.cpp
@@ -1,0 +1,42 @@
+#include "./LogSystem.hpp"
+
+namespace godot {
+    const char *LogSystem::LOG_UPDATED_SIGNAL = "log_updated";
+
+    void LogSystem::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("log", "loglevel", "line"), &LogSystem::log);
+        ClassDB::bind_method(D_METHOD("debug", "line"), &LogSystem::debug);
+        ClassDB::bind_method(D_METHOD("info", "line"), &LogSystem::info);
+        ClassDB::bind_method(D_METHOD("warning", "line"), &LogSystem::warning);
+        ClassDB::bind_method(D_METHOD("error", "line"), &LogSystem::error);
+        ADD_SIGNAL(MethodInfo(
+                LOG_UPDATED_SIGNAL, PropertyInfo(Variant::INT, "loglevel"), PropertyInfo(Variant::STRING, "line")));
+        BIND_ENUM_CONSTANT(LOGLEVEL_DEBUG);
+        BIND_ENUM_CONSTANT(LOGLEVEL_INFO);
+        BIND_ENUM_CONSTANT(LOGLEVEL_WARNING);
+        BIND_ENUM_CONSTANT(LOGLEVEL_ERROR);
+    }
+
+    LogSystem::LogSystem() = default;
+
+    void LogSystem::log(const LogLevel level, const String &line) {
+        emit_signal(LOG_UPDATED_SIGNAL, level, line);
+    }
+
+    void LogSystem::debug(const String &line) {
+        log(LogLevel::LOGLEVEL_DEBUG, line);
+    }
+
+    void LogSystem::info(const String &line) {
+        log(LogLevel::LOGLEVEL_INFO, line);
+    }
+
+    void LogSystem::warning(const String &line) {
+        log(LogLevel::LOGLEVEL_WARNING, line);
+    }
+
+    void LogSystem::error(const String &line) {
+        log(LogLevel::LOGLEVEL_ERROR, line);
+    }
+
+} // namespace godot

--- a/src/core/LogSystem.hpp
+++ b/src/core/LogSystem.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <map>
+
+#ifdef DEBUG_ENABLED
+#if defined(_MSC_VER)
+// MSVC doesn't require special handling.
+#define DEBUG(msg, ...)                                                                                                \
+    UtilityFunctions::print_rich("[color=orange](debug) " + vformat(String(msg), Array::make(__VA_ARGS__)) + "[/color]")
+#elif defined(__cplusplus) && __cplusplus >= 202002L
+// C++20 with __VA_OPT__
+#define DEBUG(msg, ...)                                                                                                \
+    UtilityFunctions::print_rich(                                                                                      \
+            "[color=orange](debug) " + vformat(String(msg) __VA_OPT__(, ) Array::make(__VA_ARGS__)) + "[/color]")
+#else
+// Use a workaround for C++11 to C++17
+#define DEBUG(msg, ...)                                                                                                \
+    UtilityFunctions::print_rich("[color=orange](debug) " + vformat(String(msg), ##__VA_ARGS__) + "[/color]")
+#endif
+#else
+#define DEBUG(msg, ...)
+#endif
+
+namespace godot {
+
+    class LogSystem : public RefCounted {
+            GDCLASS(LogSystem, RefCounted);
+
+        private:
+        public:
+            static const char *LOG_UPDATED_SIGNAL;
+
+            inline static LogSystem *get_instance() {
+                return dynamic_cast<LogSystem *>(godot::Engine::get_singleton()->get_singleton("LogSystem"));
+            }
+
+            enum LogLevel {
+                LOGLEVEL_DEBUG = 0,
+                LOGLEVEL_INFO,
+                LOGLEVEL_WARNING,
+                LOGLEVEL_ERROR,
+            };
+
+            LogSystem();
+            ~LogSystem() override = default;
+
+            void log(const LogLevel level, const String &line);
+            void debug(const String &line);
+            void info(const String &line);
+            void warning(const String &line);
+            void error(const String &line);
+
+        protected:
+            static void _bind_methods();
+    };
+} // namespace godot
+VARIANT_ENUM_CAST(LogSystem::LogLevel)

--- a/src/core/TrainController.cpp
+++ b/src/core/TrainController.cpp
@@ -160,7 +160,7 @@ namespace godot {
         /* switch_physics() raczej trzeba zostawic */
         mover->switch_physics(true);
 
-        UtilityFunctions::print("[MaSzyna::TMoverParameters] Mover initialized successfully");
+        DEBUG("[MaSzyna::TMoverParameters] Mover initialized successfully");
         emit_signal(MOVER_INITIALIZED_SIGNAL);
     }
 
@@ -211,7 +211,7 @@ namespace godot {
                 break;
             case NOTIFICATION_READY:
                 initialize_mover();
-                UtilityFunctions::print("TrainController::_ready() signals connected to train parts");
+                DEBUG("TrainController::_ready() signals connected to train parts");
 
                 emit_signal(POWER_CHANGED_SIGNAL, prev_is_powered);
                 emit_signal(RADIO_CHANNEL_CHANGED, prev_radio_channel);

--- a/src/core/TrainPart.cpp
+++ b/src/core/TrainPart.cpp
@@ -83,25 +83,25 @@ namespace godot {
         }
     }
 
-    void TrainPart::log(const TrainSystem::TrainLogLevel level, const String &line) {
+    void TrainPart::log(const LogSystem::LogLevel level, const String &line) {
         if (train_controller_node != nullptr) {
             TrainSystem::get_instance()->log(train_controller_node->get_train_id(), level, line);
         }
     }
     void TrainPart::log_debug(const String &line) {
-        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_DEBUG, line);
+        log(LogSystem::LogLevel::LOGLEVEL_DEBUG, line);
     }
 
     void TrainPart::log_info(const String &line) {
-        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_INFO, line);
+        log(LogSystem::LogLevel::LOGLEVEL_INFO, line);
     }
 
     void TrainPart::log_warning(const String &line) {
-        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_WARNING, line);
+        log(LogSystem::LogLevel::LOGLEVEL_WARNING, line);
     }
 
     void TrainPart::log_error(const String &line) {
-        log(TrainSystem::TrainLogLevel::TRAINLOGLEVEL_ERROR, line);
+        log(LogSystem::LogLevel::LOGLEVEL_ERROR, line);
     }
 
     void TrainPart::register_command(const String &command, const Callable &callback) {

--- a/src/core/TrainPart.hpp
+++ b/src/core/TrainPart.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <godot_cpp/classes/node.hpp>
+#include "./LogSystem.hpp"
 #include "./TrainSystem.hpp"
 #include "TrainController.hpp"
 
@@ -62,7 +63,7 @@ namespace godot {
             void unregister_command(const String &command, const Callable &callback);
             void send_command(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
             void broadcast_command(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
-            void log(const TrainSystem::TrainLogLevel level, const String &line);
+            void log(const LogSystem::LogLevel level, const String &line);
             void log_debug(const String &line);
             void log_info(const String &line);
             void log_warning(const String &line);

--- a/src/core/TrainSystem.hpp
+++ b/src/core/TrainSystem.hpp
@@ -7,7 +7,7 @@
 #include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <map>
-#include "./TrainLogLevel.hpp"
+#include "./LogSystem.hpp"
 
 namespace godot {
 
@@ -21,16 +21,12 @@ namespace godot {
             Dictionary commands;
 
         public:
+            static const char *TRAIN_LOG_UPDATED_SIGNAL;
+
             inline static TrainSystem *get_instance() {
                 return dynamic_cast<TrainSystem *>(godot::Engine::get_singleton()->get_singleton("TrainSystem"));
             }
 
-            enum TrainLogLevel {
-                TRAINLOGLEVEL_DEBUG = 0,
-                TRAINLOGLEVEL_INFO,
-                TRAINLOGLEVEL_WARNING,
-                TRAINLOGLEVEL_ERROR,
-            };
             TrainSystem();
             ~TrainSystem() override = default;
 
@@ -54,10 +50,7 @@ namespace godot {
             void broadcast_command(const String &command, const Variant &p1 = Variant(), const Variant &p2 = Variant());
             bool is_command_supported(const String &command);
 
-            void log(const String &train_id, const TrainLogLevel level, const String &line);
-
-            // FIXME: move to LogSystem???
-            void global_log(const TrainLogLevel level, const String &line);
+            void log(const String &train_id, const LogSystem::LogLevel level, const String &line);
 
             Dictionary get_train_state(const String &train_id);
 
@@ -65,4 +58,3 @@ namespace godot {
             static void _bind_methods();
     };
 } // namespace godot
-VARIANT_ENUM_CAST(TrainSystem::TrainLogLevel)

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -6,6 +6,7 @@
 
 #include "brakes/TrainBrake.hpp"
 #include "core/GenericTrainPart.hpp"
+#include "core/LogSystem.hpp"
 #include "core/TrainController.hpp"
 #include "core/TrainPart.hpp"
 #include "core/TrainSystem.hpp"
@@ -20,6 +21,7 @@
 using namespace godot;
 
 TrainSystem *train_system_singleton = nullptr;
+LogSystem *log_system_singleton = nullptr;
 
 void initialize_libmaszyna_module(ModuleInitializationLevel p_level) {
     if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
@@ -39,9 +41,12 @@ void initialize_libmaszyna_module(ModuleInitializationLevel p_level) {
         GDREGISTER_CLASS(TrainController);
         GDREGISTER_CLASS(TrainSecuritySystem);
         GDREGISTER_CLASS(TrainSystem);
+        GDREGISTER_CLASS(LogSystem);
 
         train_system_singleton = memnew(TrainSystem);
+        log_system_singleton = memnew(LogSystem);
         Engine::get_singleton()->register_singleton("TrainSystem", train_system_singleton);
+        Engine::get_singleton()->register_singleton("LogSystem", log_system_singleton);
     }
 }
 
@@ -52,6 +57,7 @@ void uninitialize_libmaszyna_module(ModuleInitializationLevel p_level) {
 
     if (train_system_singleton) {
         Engine::get_singleton()->unregister_singleton("TrainSystem");
+        Engine::get_singleton()->unregister_singleton("LogSystem");
         // memdelete(train_system_singleton);
         // train_system_singleton = nullptr;
     }


### PR DESCRIPTION
Solves #39 

* added `LogSystem`
* added `DEBUG` macro

Adding `PRINT_STACKTRACE` is not easy. Stacktrace is available from C++27, in "Boost" external lib, or "backtrace" (linux/unix) and "CaptureBackTrace" (windows). Too much work for now. DEBUG macro should be good enough for most cases...

----

```cpp
DEBUG("Registered train ", train_id);
```
![image](https://github.com/user-attachments/assets/ff204724-9ebe-4f01-840d-8b61299343c0)
