### PR TITLE
Add light section

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -80,7 +80,9 @@ sources = (
     + Glob("src/brakes/*.cpp")
     + Glob("src/types/*.cpp")
     + Glob("src/parsers/*.cpp")
+    + Glob("src/lighting/*.cpp")
     + Glob("src/resources/engines/*.cpp")
+    + Glob("src/resources/lighting/*.cpp")
 )
 
 if env["target"] in ["editor", "template_debug"]:

--- a/demo/hud/mover_switches.tscn
+++ b/demo/hud/mover_switches.tscn
@@ -52,6 +52,19 @@ command = "main_controller_decrease"
 unique_name_in_owner = true
 layout_mode = 2
 
+[node name="HBoxContainer3" type="HBoxContainer" parent="General"]
+layout_mode = 2
+
+[node name="LightsIncrease" parent="General/HBoxContainer3" instance=ExtResource("2_qbcao")]
+layout_mode = 2
+text = "Light selector +"
+command = "increase_light_selector_position"
+
+[node name="LightsDecrease" parent="General/HBoxContainer3" instance=ExtResource("2_qbcao")]
+layout_mode = 2
+text = "Light selector -"
+command = "decrease_light_selector_position"
+
 [node name="Security" type="HFlowContainer" parent="."]
 layout_mode = 2
 

--- a/demo/vehicles/sm42/sm_42v_1.gd
+++ b/demo/vehicles/sm42/sm_42v_1.gd
@@ -1,3 +1,6 @@
 extends TrainController
 
 var _powered:bool = false
+
+func _on_train_lightning_selector_position_changed(position: int) -> void:
+    print("New light selectior position is " + str(position))

--- a/demo/vehicles/sm42/sm_42v_1.tscn
+++ b/demo/vehicles/sm42/sm_42v_1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://c5hi8nsm1d2hb"]
+[gd_scene load_steps=18 format=3 uid="uid://c5hi8nsm1d2hb"]
 
 [ext_resource type="Script" uid="uid://bbn3nd8ts8yjx" path="res://vehicles/sm42/sm_42v_1.gd" id="1_vib8j"]
 [ext_resource type="Script" uid="uid://b6080q3nwa3xs" path="res://vehicles/sm42/cabin_interior_lights.gd" id="2_qmqy7"]
@@ -113,6 +113,11 @@ mIsat = 183.3
 fi = 2000.0
 Isat = 49.0
 
+[sub_resource type="LightListItem" id="LightListItem_ss4tc"]
+cabin_a/head_light = true
+cabin_a/left/white_signal = true
+cabin_a/right/white_signal = true
+
 [node name="SM42v1" type="TrainController"]
 train_id = "sm42v1"
 type_name = "6d"
@@ -169,3 +174,11 @@ platform/max_shift = 3.0
 
 [node name="CabinInteriorLights" type="GenericTrainPart" parent="."]
 script = ExtResource("2_qmqy7")
+
+[node name="TrainLightning" type="TrainLighting" parent="."]
+lights/wrap_selector = true
+lights/list = Array[LightListItem]([SubResource("LightListItem_ss4tc")])
+light/source = 4
+source/generator/engine = 0
+
+[connection signal="selector_position_changed" from="TrainLightning" to="." method="_on_train_lightning_selector_position_changed"]

--- a/doc_classes/LightListItem.xml
+++ b/doc_classes/LightListItem.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LightListItem" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Item for light selector indicating which lights it should light up
+	</brief_description>
+	<description>
+		Item for light selector indicating which lights it should light up. It applies to the cabin where the selector is located at
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="cabin_a/head_light" type="bool" setter="set_cabin_a_head_light" getter="get_cabin_a_head_light" default="false">
+			State of the head light in cabin A indicating whether it is lit up or not
+		</member>
+		<member name="cabin_a/left/red_signal" type="bool" setter="set_cabin_a_left_red_signal" getter="get_cabin_a_left_red_signal" default="false">
+			State of the left red signal in cabin A indicating whether it is lit up or not
+		</member>
+		<member name="cabin_a/left/white_signal" type="bool" setter="set_cabin_a_left_white_signal" getter="get_cabin_a_left_white_signal" default="false">
+			State of the left white signal in cabin A indicating whether it is lit up or not
+		</member>
+		<member name="cabin_a/right/red_signal" type="bool" setter="set_cabin_a_right_red_signal" getter="get_cabin_a_right_red_signal" default="false">
+			State of the right red signal in cabin A indicating whether it is lit up or not
+		</member>
+		<member name="cabin_a/right/white_signal" type="bool" setter="set_cabin_a_right_white_signal" getter="get_cabin_a_right_white_signal" default="false">
+			State of the right white signal in cabin A indicating whether it is lit up or not
+		</member>
+		<member name="cabin_b/head_light" type="bool" setter="set_cabin_b_head_light" getter="get_cabin_b_head_light" default="false">
+			State of the head light in cabin B indicating whether it is lit up or not
+		</member>
+		<member name="cabin_b/left/red_signal" type="bool" setter="set_cabin_b_left_red_signal" getter="get_cabin_b_left_red_signal" default="false">
+			State of the left red signal in cabin B indicating whether it is lit up or not
+		</member>
+		<member name="cabin_b/left/white_signal" type="bool" setter="set_cabin_b_left_white_signal" getter="get_cabin_b_left_white_signal" default="false">
+			State of the left white signal in cabin B indicating whether it is lit up or not
+		</member>
+		<member name="cabin_b/right/red_signal" type="bool" setter="set_cabin_b_right_red_signal" getter="get_cabin_b_right_red_signal" default="false">
+			State of the right red signal in cabin B indicating whether it is lit up or not
+		</member>
+		<member name="cabin_b/right/white_signal" type="bool" setter="set_cabin_b_right_white_signal" getter="get_cabin_b_right_white_signal" default="false">
+			State of the right white signal in cabin B indicating whether it is lit up or not
+		</member>
+	</members>
+</class>

--- a/doc_classes/TrainEngine.xml
+++ b/doc_classes/TrainEngine.xml
@@ -35,4 +35,33 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="NONE" value="0" enum="EngineType">
+			No engine is on the train/vehicle
+		</constant>
+		<constant name="DUMB" value="1" enum="EngineType">
+			Dumb
+		</constant>
+		<constant name="WHEELS_DRIVEN" value="2" enum="EngineType">
+			Wheels driven
+		</constant>
+		<constant name="ELECTRIC_SERIES_MOTOR" value="3" enum="EngineType">
+			Electric series motor
+		</constant>
+		<constant name="ELECTRIC_INDUCTION_MOTOR" value="4" enum="EngineType">
+			Electric induction motor
+		</constant>
+		<constant name="DIESEL" value="5" enum="EngineType">
+			Diesel engine
+		</constant>
+		<constant name="STEAM" value="6" enum="EngineType">
+			Steam engine
+		</constant>
+		<constant name="DIESEL_ELECTRIC" value="7" enum="EngineType">
+			Diesel-electric engine
+		</constant>
+		<constant name="MAIN" value="8" enum="EngineType">
+			Main
+		</constant>
+	</constants>
 </class>

--- a/doc_classes/TrainLighting.xml
+++ b/doc_classes/TrainLighting.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TrainLighting" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Class used for handling settings for headlight in front of both vehicle cabins
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="decrease_light_selector_position">
+			<return type="void" />
+			<description>
+				Returns current position the light wrapper is on
+			</description>
+		</method>
+		<method name="increase_light_selector_position">
+			<return type="void" />
+			<description>
+				Sets the light wrapper to desired position
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="head_light/color" type="Color" setter="set_head_light_color" getter="get_head_light_color" default="Color(255, 255, 255, 1)">
+			Color of the headlights
+		</member>
+		<member name="head_light/dimming_multiplier" type="float" setter="set_head_light_dimming_multiplier" getter="get_head_light_dimming_multiplier" default="0.6">
+			Multiplier of dimmed headlights intensity
+		</member>
+		<member name="head_light/high_beam/dimming_multiplier" type="float" setter="set_high_beam_dimmed_multiplier" getter="get_high_beam_dimmed_multiplier" default="2.5">
+			Multiplier of dimmed high beam headlights intensity
+		</member>
+		<member name="head_light/high_beam/normal_multiplier" type="float" setter="set_high_beam_multiplier" getter="get_high_beam_multiplier" default="2.8">
+			Multiplier of high beam headlights intensity
+		</member>
+		<member name="head_light/normal_multiplier" type="float" setter="set_head_light_normal_multiplier" getter="get_head_light_normal_multiplier" default="1.0">
+			Multiplier of headlights intensity
+		</member>
+		<member name="light/alternative/capacity" type="float" setter="set_alternative_light_capacity" getter="get_alternative_light_capacity" default="24.0">
+			Specifies the capacity of the alternative light source, typically measured in units like Ampere-hours (Ah). Represents the total amount of energy the alternative light source can store
+		</member>
+		<member name="light/alternative/max_voltage" type="float" setter="set_alternative_max_voltage" getter="get_alternative_max_voltage" default="24.0">
+			Specifies the maximum voltage of the alternative light source can provide
+		</member>
+		<member name="light/alternative/source" type="int" setter="set_alternative_light_source" getter="get_alternative_light_source" enum="TrainController.TrainPowerSource" default="4">
+			An integer representing the alternative power source, defined by the TrainController.TrainPowerSource enumeration
+		</member>
+		<member name="light/source" type="int" setter="set_light_source" getter="get_light_source" enum="TrainController.TrainPowerSource" default="3">
+			An integer representing the power source, defined by the TrainController.TrainPowerSource enumeration
+		</member>
+		<member name="lights/list" type="LightListItem[]" setter="set_light_position_list" getter="get_light_position_list" default="[]">
+			An array of LightListItem objects, each representing a light configuration for one selector position
+		</member>
+		<member name="lights/selector_default_position" type="int" setter="set_lights_selector_default_position" getter="get_lights_selector_default_position" default="0">
+			An integer representing the default position of the light selector
+		</member>
+		<member name="lights/selector_position" type="int" setter="set_light_selector_position" getter="get_light_selector_position" default="0">
+			An integer representing the current position of the light selector
+		</member>
+		<member name="lights/wrap_selector" type="bool" setter="set_wrap_light_selector" getter="get_wrap_light_selector" default="false">
+			If true, rotating the selector past the last position will return to the first position. If false, it will stop at the last position.
+		</member>
+		<member name="source/accumulator/max_voltage" type="float" setter="set_max_accumulator_voltage" getter="get_max_accumulator_voltage" default="0.0">
+			Represents the highest voltage the accumulator can reach when fully charged.
+		</member>
+		<member name="source/accumulator/recharge_source" type="int" setter="set_accumulator_recharge_source" getter="get_accumulator_recharge_source" enum="TrainController.TrainPowerSource" default="3">
+			An integer representing the power source, defined by the TrainController.TrainPowerSource enumeration.
+		</member>
+		<member name="source/generator/engine" type="int" setter="set_generator_engine" getter="get_generator_engine" enum="TrainEngine.EngineType" default="8">
+			An integer representing the engine type, defined by the TrainEngine.EngineType enumeration
+		</member>
+	</members>
+	<signals>
+		<signal name="selector_position_changed">
+			<param index="0" name="position" type="int" />
+			<description>
+				Emitted whenever current position of the light wrapper changes with the new position as an [code]position[/code] parameter
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/src/core/TrainController.hpp
+++ b/src/core/TrainController.hpp
@@ -79,6 +79,46 @@ namespace godot {
                 POWER_TYPE_STEAM
             };
 
+            const std::map<TrainPowerSource, TPowerSource> power_source_map = {
+                    {TrainPowerSource::POWER_SOURCE_NOT_DEFINED, TPowerSource::NotDefined},
+                    {TrainPowerSource::POWER_SOURCE_INTERNAL, TPowerSource::InternalSource},
+                    {TrainPowerSource::POWER_SOURCE_TRANSDUCER, TPowerSource::Transducer},
+                    {TrainPowerSource::POWER_SOURCE_GENERATOR, TPowerSource::Generator},
+                    {TrainPowerSource::POWER_SOURCE_ACCUMULATOR, TPowerSource::Accumulator},
+                    {TrainPowerSource::POWER_SOURCE_CURRENTCOLLECTOR, TPowerSource::CurrentCollector},
+                    {TrainPowerSource::POWER_SOURCE_POWERCABLE, TPowerSource::PowerCable},
+                    {TrainPowerSource::POWER_SOURCE_HEATER, TPowerSource::Heater},
+                    {TrainPowerSource::POWER_SOURCE_MAIN, TPowerSource::Main}
+            };
+
+            const std::map<TPowerSource, TrainPowerSource> tpower_source_map = {
+                {TPowerSource::NotDefined, TrainPowerSource::POWER_SOURCE_NOT_DEFINED},
+                {TPowerSource::InternalSource, TrainPowerSource::POWER_SOURCE_INTERNAL},
+                {TPowerSource::Transducer, TrainPowerSource::POWER_SOURCE_TRANSDUCER},
+                {TPowerSource::Generator, TrainPowerSource::POWER_SOURCE_GENERATOR},
+                {TPowerSource::Accumulator, TrainPowerSource::POWER_SOURCE_ACCUMULATOR},
+                {TPowerSource::CurrentCollector, TrainPowerSource::POWER_SOURCE_CURRENTCOLLECTOR},
+                {TPowerSource::PowerCable, TrainPowerSource::POWER_SOURCE_POWERCABLE},
+                {TPowerSource::Heater, TrainPowerSource::POWER_SOURCE_HEATER},
+                {TPowerSource::Main, TrainPowerSource::POWER_SOURCE_MAIN}
+            };
+
+            const std::map<TrainPowerType, TPowerType> power_type_map = {
+                    {TrainPowerType::POWER_TYPE_NONE, TPowerType::NoPower},
+                    {TrainPowerType::POWER_TYPE_BIO, TPowerType::BioPower},
+                    {TrainPowerType::POWER_TYPE_MECH, TPowerType::MechPower},
+                    {TrainPowerType::POWER_TYPE_ELECTRIC, TPowerType::ElectricPower},
+                    {TrainPowerType::POWER_TYPE_STEAM, TPowerType::SteamPower}
+            };
+
+            const std::map<TPowerType, TrainPowerType> tpower_type_map = {
+                    {TPowerType::NoPower, TrainPowerType::POWER_TYPE_NONE},
+                    {TPowerType::BioPower, TrainPowerType::POWER_TYPE_BIO},
+                    {TPowerType::MechPower, TrainPowerType::POWER_TYPE_MECH},
+                    {TPowerType::ElectricPower, TrainPowerType::POWER_TYPE_ELECTRIC},
+                    {TPowerType::SteamPower, TrainPowerType::POWER_TYPE_STEAM}
+            };
+
             static const char *MOVER_CONFIG_CHANGED_SIGNAL;
             static const char *MOVER_INITIALIZED_SIGNAL;
             static const char *POWER_CHANGED_SIGNAL;

--- a/src/engines/TrainDieselElectricEngine.cpp
+++ b/src/engines/TrainDieselElectricEngine.cpp
@@ -3,7 +3,7 @@
 namespace godot {
     void TrainDieselElectricEngine::_bind_methods() {}
 
-    TEngineType TrainDieselElectricEngine::get_engine_type() {
-        return TEngineType::DieselElectric;
+    TrainEngine::EngineType TrainDieselElectricEngine::get_engine_type() {
+        return TrainEngine::EngineType::DIESEL_ELECTRIC;
     }
 } // namespace godot

--- a/src/engines/TrainDieselElectricEngine.hpp
+++ b/src/engines/TrainDieselElectricEngine.hpp
@@ -9,6 +9,6 @@ namespace godot {
             static void _bind_methods();
 
         protected:
-            TEngineType get_engine_type() override;
+            TrainEngine::EngineType get_engine_type() override;
     };
 } // namespace godot

--- a/src/engines/TrainDieselEngine.cpp
+++ b/src/engines/TrainDieselEngine.cpp
@@ -31,8 +31,8 @@ namespace godot {
                 "set_wwlist", "get_wwlist");
     }
 
-    TEngineType TrainDieselEngine::get_engine_type() {
-        return TEngineType::DieselEngine;
+    TrainEngine::EngineType TrainDieselEngine::get_engine_type() {
+        return TrainEngine::EngineType::DIESEL;
     }
 
     void TrainDieselEngine::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {

--- a/src/engines/TrainDieselEngine.hpp
+++ b/src/engines/TrainDieselEngine.hpp
@@ -18,7 +18,7 @@ namespace godot {
             TypedArray<WWListItem> wwlist;
 
         protected:
-            TEngineType get_engine_type() override;
+            EngineType get_engine_type() override;
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
             void _register_commands() override;

--- a/src/engines/TrainElectricEngine.hpp
+++ b/src/engines/TrainElectricEngine.hpp
@@ -7,10 +7,12 @@ namespace godot {
 
     class TrainElectricEngine : public TrainEngine {
             GDCLASS(TrainElectricEngine, TrainEngine)
-        public:
+        private:
+            const TrainController *_controller = memnew(TrainController);
 
+        public:
             static void _bind_methods();
-            TrainController::TrainPowerSource power_source = static_cast<TrainController::TrainPowerSource>(static_cast<int>(TPowerSource::NotDefined));
+            TrainController::TrainPowerSource power_source = TrainController::POWER_SOURCE_NOT_DEFINED;
             int collectors_no = 0;
             float max_voltage = 0;
             float max_current = 0;
@@ -49,16 +51,10 @@ namespace godot {
              */
             float required_main_switch_voltage = 0.6f * max_voltage;
             float transducer_input_voltage = 0;
-            TrainController::TrainPowerSource accumulator_recharge_source = TrainController::TrainPowerSource::POWER_SOURCE_NOT_DEFINED;
+            TrainController::TrainPowerSource accumulator_recharge_source =
+                    TrainController::TrainPowerSource::POWER_SOURCE_NOT_DEFINED;
             TrainController::TrainPowerType power_cable_power_trans = TrainController::TrainPowerType::POWER_TYPE_NONE;
             float power_cable_steam_pressure = 0;
-            //@TODO: Implement bitmask for PhysicalLayout
-
-        protected:
-            void _do_update_internal_mover(TMoverParameters *mover) override;
-            void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
-
-        public:
             void set_engine_power_source(TrainController::TrainPowerSource p_source);
             TrainController::TrainPowerSource get_engine_power_source() const;
             int get_number_of_collectors() const;
@@ -95,5 +91,10 @@ namespace godot {
             void converter(bool p_enabled);
             void _register_commands() override;
             void _unregister_commands() override;
+            //@TODO: Implement bitmask for PhysicalLayout
+
+        protected:
+            void _do_update_internal_mover(TMoverParameters *mover) override;
+            void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
     };
 } // namespace godot

--- a/src/engines/TrainElectricSeriesEngine.cpp
+++ b/src/engines/TrainElectricSeriesEngine.cpp
@@ -15,8 +15,8 @@ namespace godot {
                 PropertyInfo(Variant::FLOAT, "winding_resistance"), "set_winding_resistance", "get_winding_resistance");
     }
 
-    TEngineType TrainElectricSeriesEngine::get_engine_type() {
-        return TEngineType::ElectricSeriesMotor;
+    TrainEngine::EngineType TrainElectricSeriesEngine::get_engine_type() {
+        return TrainEngine::EngineType::ELECTRIC_SERIES_MOTOR;
     }
 
     void TrainElectricSeriesEngine::_do_update_internal_mover(TMoverParameters *mover) {

--- a/src/engines/TrainElectricSeriesEngine.hpp
+++ b/src/engines/TrainElectricSeriesEngine.hpp
@@ -14,7 +14,7 @@ namespace godot {
             double winding_resistance = 0.0; // WindingRes -> WindingRes
 
         protected:
-            TEngineType get_engine_type() override;
+            EngineType get_engine_type() override;
             void _do_update_internal_mover(TMoverParameters *mover) override;
 
         public:

--- a/src/engines/TrainEngine.cpp
+++ b/src/engines/TrainEngine.cpp
@@ -14,10 +14,20 @@ namespace godot {
                 "set_motor_param_table", "get_motor_param_table");
         ADD_SIGNAL(MethodInfo("engine_start"));
         ADD_SIGNAL(MethodInfo("engine_stop"));
+
+        BIND_ENUM_CONSTANT(NONE);
+        BIND_ENUM_CONSTANT(DUMB);
+        BIND_ENUM_CONSTANT(WHEELS_DRIVEN);
+        BIND_ENUM_CONSTANT(ELECTRIC_SERIES_MOTOR);
+        BIND_ENUM_CONSTANT(ELECTRIC_INDUCTION_MOTOR);
+        BIND_ENUM_CONSTANT(DIESEL);
+        BIND_ENUM_CONSTANT(STEAM);
+        BIND_ENUM_CONSTANT(DIESEL_ELECTRIC);
+        BIND_ENUM_CONSTANT(MAIN);
     }
 
     void TrainEngine::_do_update_internal_mover(TMoverParameters *mover) {
-        mover->EngineType = get_engine_type();
+        mover->EngineType = engine_type_map.at(get_engine_type());
 
         /* FIXME: for testing purposes */
         mover->GroundRelay = true;

--- a/src/engines/TrainEngine.hpp
+++ b/src/engines/TrainEngine.hpp
@@ -9,11 +9,38 @@ namespace godot {
     class TrainEngine : public TrainPart {
             GDCLASS(TrainEngine, TrainPart)
         public:
+            enum EngineType {
+                NONE,
+                DUMB,
+                WHEELS_DRIVEN,
+                ELECTRIC_SERIES_MOTOR,
+                ELECTRIC_INDUCTION_MOTOR,
+                DIESEL,
+                STEAM,
+                DIESEL_ELECTRIC,
+                MAIN
+            };
+
+            const std::map<EngineType, TEngineType> engine_type_map = {
+                    {NONE, TEngineType::None},
+                    {DUMB, TEngineType::Dumb},
+                    {WHEELS_DRIVEN, TEngineType::WheelsDriven},
+                    {ELECTRIC_SERIES_MOTOR, TEngineType::ElectricSeriesMotor},
+                    {ELECTRIC_INDUCTION_MOTOR, TEngineType::ElectricInductionMotor},
+                    {DIESEL, TEngineType::DieselEngine},
+                    {STEAM, TEngineType::SteamEngine},
+                    {DIESEL_ELECTRIC, TEngineType::DieselElectric},
+                    {MAIN, TEngineType::Main}
+            };
+
+            TypedArray<MotorParameter> get_motor_param_table();
+            void set_motor_param_table(const TypedArray<MotorParameter> &p_motor_param_table);
+            void main_switch(bool p_enabled);
             static void _bind_methods();
             TypedArray<MotorParameter> motor_param_table;
 
         protected:
-            virtual TEngineType get_engine_type() = 0;
+            virtual EngineType get_engine_type() = 0;
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
             void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) override;
@@ -21,8 +48,7 @@ namespace godot {
             void _unregister_commands() override;
 
         public:
-            TypedArray<MotorParameter> get_motor_param_table();
-            void set_motor_param_table(const TypedArray<MotorParameter> &p_motor_param_table);
-            void main_switch(bool p_enabled);
     };
 } // namespace godot
+
+VARIANT_ENUM_CAST(TrainEngine::EngineType);

--- a/src/lighting/TrainLighting.cpp
+++ b/src/lighting/TrainLighting.cpp
@@ -1,0 +1,302 @@
+#include "TrainLighting.hpp"
+
+namespace godot {
+    const char *TrainLighting::SELECTOR_POSITION_CHANGED_SIGNAL = "selector_position_changed";
+
+    void TrainLighting::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("set_head_light_color", "color"), &TrainLighting::set_head_light_color);
+        ClassDB::bind_method(D_METHOD("get_head_light_color"), &TrainLighting::get_head_light_color);
+        ADD_PROPERTY(PropertyInfo(Variant::COLOR, "head_light/color"), "set_head_light_color", "get_head_light_color");
+        ClassDB::bind_method(D_METHOD("set_head_light_dimming_multiplier", "multiplier"), &TrainLighting::set_dimming_multiplier);
+        ClassDB::bind_method(D_METHOD("get_head_light_dimming_multiplier"), &TrainLighting::get_dimming_multiplier);
+        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/dimming_multiplier"), "set_head_light_dimming_multiplier", "get_head_light_dimming_multiplier");
+        ClassDB::bind_method(D_METHOD("set_head_light_normal_multiplier", "multiplier"), &TrainLighting::set_normal_multiplier);
+        ClassDB::bind_method(D_METHOD("get_head_light_normal_multiplier"), &TrainLighting::get_normal_multiplier);
+        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/normal_multiplier"), "set_head_light_normal_multiplier", "get_head_light_normal_multiplier");
+        ClassDB::bind_method(D_METHOD("set_high_beam_dimmed_multiplier", "multiplier"), &TrainLighting::set_high_beam_dimmed_multiplier);
+        ClassDB::bind_method(D_METHOD("get_high_beam_dimmed_multiplier"), &TrainLighting::get_high_beam_dimmed_multiplier);
+        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/high_beam/dimming_multiplier"), "set_high_beam_dimmed_multiplier", "get_high_beam_dimmed_multiplier");
+        ClassDB::bind_method(D_METHOD("set_high_beam_multiplier", "multiplier"), &TrainLighting::set_high_beam_multiplier);
+        ClassDB::bind_method(D_METHOD("get_high_beam_multiplier"), &TrainLighting::get_high_beam_multiplier);
+        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/high_beam/normal_multiplier"), "set_high_beam_multiplier", "get_high_beam_multiplier");
+        ClassDB::bind_method(
+                D_METHOD("set_lights_selector_default_position", "position"), &TrainLighting::set_default_selector_position);
+        ClassDB::bind_method(D_METHOD("get_lights_selector_default_position"), &TrainLighting::get_default_selector_position);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::INT, "lights/selector_default_position"),
+                "set_lights_selector_default_position", "get_lights_selector_default_position");
+        ClassDB::bind_method(D_METHOD("set_light_selector_position", "light_selector_position"), &TrainLighting::set_selector_position);
+        ClassDB::bind_method(D_METHOD("get_light_selector_position"), &TrainLighting::get_selector_position);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::INT, "lights/selector_position"),
+                "set_light_selector_position", "get_light_selector_position");
+        ClassDB::bind_method(
+                D_METHOD("set_wrap_light_selector", "wrap"), &TrainLighting::set_wrap_light_selector);
+        ClassDB::bind_method(D_METHOD("get_wrap_light_selector"), &TrainLighting::get_wrap_light_selector);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::BOOL, "lights/wrap_selector"),
+                "set_wrap_light_selector", "get_wrap_light_selector");
+        ClassDB::bind_method(D_METHOD("set_light_position_list", "light_position_list"), &TrainLighting::set_light_position_list);
+        ClassDB::bind_method(D_METHOD("get_light_position_list"), &TrainLighting::get_light_position_list);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::ARRAY, "lights/list", PROPERTY_HINT_TYPE_STRING, String::num(Variant::OBJECT) + "/" + String::num(PROPERTY_HINT_RESOURCE_TYPE) + ":LightListItem", PROPERTY_USAGE_DEFAULT, "TypedArray<LightListItem>"),
+                "set_light_position_list", "get_light_position_list");
+
+        ClassDB::bind_method(D_METHOD("set_light_source", "light_source"), &TrainLighting::set_light_source);
+        ClassDB::bind_method(D_METHOD("get_light_source"), &TrainLighting::get_light_source);
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::INT, "light/source", PROPERTY_HINT_ENUM,
+                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
+                        "Main"),
+                "set_light_source", "get_light_source");
+        ClassDB::bind_method(
+                D_METHOD("set_generator_engine", "generator_engine"), &TrainLighting::set_generator_engine);
+        ClassDB::bind_method(D_METHOD("get_generator_engine"), &TrainLighting::get_generator_engine);
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::INT, "source/generator/engine", PROPERTY_HINT_ENUM,
+                        "None,Dumb,WheelsDriven,ElectricSeriesMotor,ElectricInductionMotor,DieselEngine,SteamEngine,"
+                        "DieselElectric,Main"),
+                "set_generator_engine", "get_generator_engine");
+        ClassDB::bind_method(
+                D_METHOD("set_max_accumulator_voltage", "max_accumulator_voltage"),
+                &TrainLighting::set_max_accumulator_voltage);
+        ClassDB::bind_method(D_METHOD("get_max_accumulator_voltage"), &TrainLighting::get_max_accumulator_voltage);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::FLOAT, "source/accumulator/max_voltage"), "set_max_accumulator_voltage",
+                "get_max_accumulator_voltage");
+        ClassDB::bind_method(
+                D_METHOD("set_alternative_light_source", "light_source"),
+                &TrainLighting::set_alternative_light_source);
+        ClassDB::bind_method(D_METHOD("get_alternative_light_source"), &TrainLighting::get_alternative_light_source);
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::INT, "light/alternative/source", PROPERTY_HINT_ENUM,
+                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
+                        "Main"),
+                "set_alternative_light_source", "get_alternative_light_source");
+        ClassDB::bind_method(
+                D_METHOD("set_alternative_max_voltage", "alternative_max_voltage"),
+                &TrainLighting::set_alternative_max_voltage);
+        ClassDB::bind_method(D_METHOD("get_alternative_max_voltage"), &TrainLighting::get_alternative_max_voltage);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::FLOAT, "light/alternative/max_voltage"), "set_alternative_max_voltage",
+                "get_alternative_max_voltage");
+        ClassDB::bind_method(
+                D_METHOD("set_alternative_light_capacity", "light_source"),
+                &TrainLighting::set_alternative_light_capacity);
+        ClassDB::bind_method(
+                D_METHOD("get_alternative_light_capacity"), &TrainLighting::get_alternative_light_capacity);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::FLOAT, "light/alternative/capacity"), "set_alternative_light_capacity",
+                "get_alternative_light_capacity");
+        ClassDB::bind_method(
+                D_METHOD("set_accumulator_recharge_source", "recharge_source"),
+                &TrainLighting::set_accumulator_recharge_source);
+        ClassDB::bind_method(
+                D_METHOD("get_accumulator_recharge_source"), &TrainLighting::get_accumulator_recharge_source);
+        ADD_PROPERTY(
+                PropertyInfo(
+                        Variant::INT, "source/accumulator/recharge_source", PROPERTY_HINT_ENUM,
+                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
+                        "Main"),
+                "set_accumulator_recharge_source", "get_accumulator_recharge_source");
+        ClassDB::bind_method(D_METHOD("increase_light_selector_position"), &TrainLighting::increase_light_selector_position);
+        ClassDB::bind_method(D_METHOD("decrease_light_selector_position"), &TrainLighting::decrease_light_selector_position);
+        ADD_SIGNAL(MethodInfo(SELECTOR_POSITION_CHANGED_SIGNAL, PropertyInfo(Variant::INT, "position")));
+    }
+
+    void TrainLighting::_do_update_internal_mover(TMoverParameters *mover) {
+        ASSERT_MOVER(mover);
+        TrainPart::_do_update_internal_mover(mover);
+        mover->LightsPosNo = static_cast<int>(light_position_list.size()); // To fix narrowing conversion from int64_t to int
+        mover->LightsWrap = wrap_light_selector;
+        mover->LightsDefPos = default_selector_position;
+        mover->LightPower = 0; //LightPower is used there but declared in the Param section in the .fiz file
+        mover->LightPowerSource.SourceType = _controller->power_source_map.at(light_source);
+        mover->AlterLightPowerSource.SourceType = _controller->power_source_map.at(alternative_light_source);
+        mover->LightsPos = selector_position;
+    }
+
+    void TrainLighting::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {
+        ASSERT_MOVER(mover);
+        state["light_position"] = mover->LightsPosNo;
+        state["light_power"] = mover->LightPower;
+        state["power_source"] = _controller->tpower_source_map.at(mover->LightPowerSource.SourceType);
+    }
+
+    void TrainLighting::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) {
+        TrainPart::_do_fetch_config_from_mover(mover, config);
+    }
+
+    void TrainLighting::_register_commands() {
+        register_command("increase_light_selector_position", Callable(this, "increase_light_selector_position"));
+        register_command("decrease_light_selector_position", Callable(this, "decrease_light_selector_position"));
+        TrainPart::_register_commands();
+    }
+
+    void TrainLighting::_unregister_commands() {
+        unregister_command("increase_light_selector_position", Callable(this, "increase_light_selector_position"));
+        unregister_command("decrease_light_selector_position", Callable(this, "decrease_light_selector_position"));
+        TrainPart::_unregister_commands();
+    }
+
+    void TrainLighting::set_light_source(const TrainController::TrainPowerSource p_light_source) {
+        light_source = p_light_source;
+        _dirty = true;
+    }
+
+    TrainController::TrainPowerSource TrainLighting::get_light_source() const {
+        return light_source;
+    }
+
+    void TrainLighting::set_generator_engine(const TrainEngine::EngineType p_generator_engine) {
+        generator_engine = p_generator_engine;
+        _dirty = true;
+    }
+
+    TrainEngine::EngineType TrainLighting::get_generator_engine() const {
+        return generator_engine;
+    }
+
+    void TrainLighting::set_max_accumulator_voltage(const double p_max_accumulator_voltage) {
+        max_accumulator_voltage = p_max_accumulator_voltage;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_max_accumulator_voltage() const {
+        return max_accumulator_voltage;
+    }
+
+    void TrainLighting::set_alternative_light_source(const TrainController::TrainPowerSource p_light_source) {
+        alternative_light_source = p_light_source;
+        _dirty = true;
+    }
+
+    TrainController::TrainPowerSource TrainLighting::get_alternative_light_source() const {
+        return alternative_light_source;
+    }
+
+    void TrainLighting::set_alternative_max_voltage(const double p_max_accumulator_voltage) {
+        max_accumulator_voltage = p_max_accumulator_voltage;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_alternative_max_voltage() const {
+        return alternative_max_voltage;
+    }
+
+    void TrainLighting::set_alternative_light_capacity(const double p_max_accumulator_voltage) {
+        max_accumulator_voltage = p_max_accumulator_voltage;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_alternative_light_capacity() const {
+        return alternative_max_voltage;
+    }
+
+    void TrainLighting::set_accumulator_recharge_source(
+            const TrainController::TrainPowerSource p_accumulator_recharge_source) {
+        accumulator_recharge_source = p_accumulator_recharge_source;
+        _dirty = true;
+    }
+
+    TrainController::TrainPowerSource TrainLighting::get_accumulator_recharge_source() const {
+        return accumulator_recharge_source;
+    }
+
+    void TrainLighting::set_light_position_list(const TypedArray<LightListItem> &p_light_position_list) {
+        light_position_list.clear();
+        light_position_list.append_array(p_light_position_list);
+        _dirty = true;
+    }
+
+    TypedArray<LightListItem> TrainLighting::get_light_position_list() const {
+        return light_position_list;
+    }
+
+    void TrainLighting::set_wrap_light_selector(const bool p_wrap_light_selector) {
+        wrap_light_selector = p_wrap_light_selector;
+        _dirty = true;
+    }
+
+    bool TrainLighting::get_wrap_light_selector() const {
+        return wrap_light_selector;
+    }
+
+    void TrainLighting::set_default_selector_position(const int p_selector_position) {
+        default_selector_position = p_selector_position;
+        _dirty = true;
+    }
+
+    int TrainLighting::get_default_selector_position() const {
+        return default_selector_position;
+    }
+
+    void TrainLighting::set_selector_position(const int p_selector_position) {
+        selector_position = p_selector_position;
+        emit_signal(SELECTOR_POSITION_CHANGED_SIGNAL, p_selector_position);
+        _dirty = true;
+    }
+
+    int TrainLighting::get_selector_position() const {
+        return selector_position;
+    }
+
+    void TrainLighting::set_head_light_color(const Color p_head_light_color) {
+        head_light_color = p_head_light_color;
+        _dirty = true;
+    }
+
+    Color TrainLighting::get_head_light_color() const {
+        return head_light_color;
+    }
+
+    void TrainLighting::set_dimming_multiplier(const double p_dimming_multiplier) {
+        dimming_multiplier = p_dimming_multiplier;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_dimming_multiplier() const {
+        return dimming_multiplier;
+    }
+
+    void TrainLighting::set_normal_multiplier(const double p_normal_multiplier) {
+        normal_multiplier = p_normal_multiplier;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_normal_multiplier() const {
+        return normal_multiplier;
+    }
+
+    void TrainLighting::set_high_beam_dimmed_multiplier(const double p_high_beam_dimmed_multiplier) {
+        high_beam_dimmed_multiplier = p_high_beam_dimmed_multiplier;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_high_beam_dimmed_multiplier() const {
+        return high_beam_dimmed_multiplier;
+    }
+
+    void TrainLighting::set_high_beam_multiplier(const double p_high_beam_multiplier) {
+        high_beam_multiplier = p_high_beam_multiplier;
+        _dirty = true;
+    }
+
+    double TrainLighting::get_high_beam_multiplier() const {
+        return high_beam_multiplier;
+    }
+
+    void TrainLighting::increase_light_selector_position() {
+        if ((selector_position + 1) < light_position_list.size()) {
+            selector_position++;
+        }
+    }
+    void TrainLighting::decrease_light_selector_position() {
+        if ((selector_position + 1) > light_position_list.size()) {
+            selector_position--;
+        }}
+
+} // namespace godot

--- a/src/lighting/TrainLighting.hpp
+++ b/src/lighting/TrainLighting.hpp
@@ -1,0 +1,115 @@
+#pragma once
+#include "../core/TrainPart.hpp"
+#include "../engines/TrainElectricEngine.hpp"
+#include "resources/lighting/LightListItem.hpp"
+#include <godot_cpp/classes/node.hpp>
+
+namespace godot {
+    class TrainController;
+    class TrainLighting : public TrainPart {
+            GDCLASS(TrainLighting, TrainPart);
+
+        private:
+            static void _bind_methods();
+            const TrainController *_controller = memnew(TrainController);
+        protected:
+            void _do_update_internal_mover(TMoverParameters *mover) override;
+            void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
+            void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) override;
+            void _register_commands() override;
+            void _unregister_commands() override;
+        public:
+            static const char* SELECTOR_POSITION_CHANGED_SIGNAL;
+
+            TypedArray<LightListItem> light_position_list;
+
+            int selector_position = 0;
+
+            /**
+             * Whether a selector can turn in 360 deg or not
+             */
+            bool wrap_light_selector = false;
+
+            /**
+             * Default position of the light selector
+             */
+            int default_selector_position = 0;
+
+            /**
+             * Generator for light power. Default value taken from internal mover
+             */
+            TrainController::TrainPowerSource light_source = TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR;
+
+            /**
+             * Engine type of the generator
+             */
+            TrainEngine::EngineType generator_engine = TrainEngine::EngineType::MAIN;
+
+            /**
+             * Accumulator capacity for an alternative light source. Default value from internal mover
+             */
+            double max_accumulator_voltage = 0.0;
+
+            /**
+             * Alternative generator for light power. Default value taken from internal mover
+             */
+            TrainController::TrainPowerSource alternative_light_source = TrainController::TrainPowerSource::POWER_SOURCE_ACCUMULATOR;
+
+            /**
+             * Accumulator capacity for an alternative light power source. Default value from internal mover
+             */
+            double alternative_max_voltage = 24.0;
+
+            /**
+             * Accumulator capacity for an alternative light power source. Default value from internal mover
+             */
+            double alternative_light_capacity = 495.0;
+
+            /**
+             * Accumulator recharge source for an alternative light power source. Default value from internal mover
+             */
+            TrainController::TrainPowerSource accumulator_recharge_source = TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR;
+
+            Color head_light_color = Color(255, 255, 255);
+            double dimming_multiplier = 0.6;
+            double normal_multiplier = 1.0;
+            double high_beam_dimmed_multiplier = 2.5;
+            double high_beam_multiplier = 2.8;
+            int instrument_light_type = 0; // ABu 030405 - swiecenie uzaleznione od: 0-nic, 1-obw.gl, 2-przetw., 3-rozrzad, 4-external lights
+            void set_light_source(TrainController::TrainPowerSource p_light_source);
+            TrainController::TrainPowerSource get_light_source() const;
+            void set_generator_engine(TrainEngine::EngineType p_generator_engine);
+            TrainEngine::EngineType get_generator_engine() const;
+            void set_max_accumulator_voltage(double p_max_accumulator_voltage);
+            double get_max_accumulator_voltage() const;
+            void set_alternative_light_source(TrainController::TrainPowerSource p_light_source);
+            TrainController::TrainPowerSource get_alternative_light_source() const;
+            void set_alternative_max_voltage(double p_max_accumulator_voltage);
+            double get_alternative_max_voltage() const;
+            void set_alternative_light_capacity(double p_max_accumulator_voltage);
+            double get_alternative_light_capacity() const;
+            void set_accumulator_recharge_source(TrainController::TrainPowerSource p_accumulator_recharge_source);
+            TrainController::TrainPowerSource get_accumulator_recharge_source() const;
+            void set_light_position_list(const TypedArray<LightListItem> &p_light_position_list);
+            TypedArray<LightListItem> get_light_position_list() const;
+            void set_wrap_light_selector(bool p_wrap_light_selector);
+            bool get_wrap_light_selector() const;
+            void set_default_selector_position(int p_selector_position);
+            int get_default_selector_position() const;
+            void set_selector_position(int p_selector_position);
+            int get_selector_position() const;
+            void set_head_light_color(Color p_head_light_color);
+            Color get_head_light_color() const;
+            void set_dimming_multiplier(double p_dimming_multiplier);
+            double get_dimming_multiplier() const;
+            void set_normal_multiplier(double p_normal_multiplier);
+            double get_normal_multiplier() const;
+            void set_high_beam_dimmed_multiplier(double p_high_beam_dimmed_multiplier);
+            double get_high_beam_dimmed_multiplier() const;
+            void set_high_beam_multiplier(double p_high_beam_multiplier);
+            double get_high_beam_multiplier() const;
+            void increase_light_selector_position();
+            void decrease_light_selector_position();
+
+    };
+} // namespace godot

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -10,10 +10,12 @@
 #include "engines/TrainElectricEngine.hpp"
 #include "engines/TrainElectricSeriesEngine.hpp"
 #include "engines/TrainEngine.hpp"
+#include "lighting/TrainLighting.hpp"
 #include "parsers/maszyna_parser.hpp"
 #include "register_types.h"
 #include "resources/engines/MotorParameter.hpp"
 #include "resources/engines/WWListItem.hpp"
+#include "resources/lighting/LightListItem.hpp"
 #include "systems/TrainSecuritySystem.hpp"
 #include <gdextension_interface.h>
 #include <godot_cpp/classes/engine.hpp>
@@ -44,9 +46,11 @@ void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
         GDREGISTER_CLASS(TrainController);
         GDREGISTER_CLASS(TrainSecuritySystem);
         GDREGISTER_CLASS(TrainSystem);
+        GDREGISTER_CLASS(TrainLighting)
         GDREGISTER_CLASS(LogSystem);
         GDREGISTER_CLASS(WWListItem);
-        GDREGISTER_CLASS(MotorParameter)
+        GDREGISTER_CLASS(MotorParameter);
+        GDREGISTER_CLASS(LightListItem)
 
         train_system_singleton = memnew(TrainSystem);
         log_system_singleton = memnew(LogSystem);

--- a/src/resources/lighting/LightListItem.cpp
+++ b/src/resources/lighting/LightListItem.cpp
@@ -1,0 +1,138 @@
+#include "LightListItem.hpp"
+
+namespace godot {
+    void LightListItem::_bind_methods() {
+        //Cabin A
+        ClassDB::bind_method(D_METHOD("set_cabin_a_head_light", "head_light"), &LightListItem::set_cabin_a_head_light);
+        ClassDB::bind_method(D_METHOD("get_cabin_a_head_light"), &LightListItem::get_cabin_a_head_light);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/head_light"), "set_cabin_a_head_light", "get_cabin_a_head_light");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_a_left_white_signal", "left_white_signal"), &LightListItem::set_cabin_a_left_white_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_a_left_white_signal"), &LightListItem::get_cabin_a_left_white_signal);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::BOOL, "cabin_a/left/white_signal"), "set_cabin_a_left_white_signal", "get_cabin_a_left_white_signal");
+
+        ClassDB::bind_method(D_METHOD("set_cabin_a_left_red_signal", "left_red_signal"), &LightListItem::set_cabin_a_left_red_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_a_left_red_signal"), &LightListItem::get_cabin_a_left_red_signal);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/left/red_signal"), "set_cabin_a_left_red_signal", "get_cabin_a_left_red_signal");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_a_right_white_signal", "right_white_light"), &LightListItem::set_cabin_a_right_white_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_a_right_white_signal"), &LightListItem::get_cabin_a_right_white_signal);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::BOOL, "cabin_a/right/white_signal"), "set_cabin_a_right_white_signal", "get_cabin_a_right_white_signal");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_a_right_red_signal", "right_red_signal"), &LightListItem::set_cabin_a_right_red_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_a_right_red_signal"), &LightListItem::get_cabin_a_right_red_signal);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/right/red_signal"), "set_cabin_a_right_red_signal", "get_cabin_a_right_red_signal");
+
+        //Cabin B
+
+        ClassDB::bind_method(D_METHOD("set_cabin_b_head_light", "head_light"), &LightListItem::set_cabin_b_head_light);
+        ClassDB::bind_method(D_METHOD("get_cabin_b_head_light"), &LightListItem::get_cabin_b_head_light);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/head_light"), "set_cabin_b_head_light", "get_cabin_b_head_light");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_b_left_white_signal", "left_white_signal"), &LightListItem::set_cabin_b_left_white_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_b_left_white_signal"), &LightListItem::get_cabin_b_left_white_signal);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::BOOL, "cabin_b/left/white_signal"), "set_cabin_b_left_white_signal", "get_cabin_b_left_white_signal");
+
+        ClassDB::bind_method(D_METHOD("set_cabin_b_left_red_signal", "left_red_signal"), &LightListItem::set_cabin_b_left_red_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_b_left_red_signal"), &LightListItem::get_cabin_b_left_red_signal);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/left/red_signal"), "set_cabin_b_left_red_signal", "get_cabin_b_left_red_signal");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_b_right_white_signal", "left_right_light"), &LightListItem::set_cabin_b_right_white_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_b_right_white_signal"), &LightListItem::get_cabin_b_right_white_signal);
+        ADD_PROPERTY(
+                PropertyInfo(Variant::BOOL, "cabin_b/right/white_signal"), "set_cabin_b_right_white_signal", "get_cabin_b_right_white_signal");
+
+        ClassDB::bind_method(
+                D_METHOD("set_cabin_b_right_red_signal", "right_red_signal"), &LightListItem::set_cabin_b_right_red_signal);
+        ClassDB::bind_method(D_METHOD("get_cabin_b_right_red_signal"), &LightListItem::get_cabin_b_right_red_signal);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/right/red_signal"), "set_cabin_b_right_red_signal", "get_cabin_b_right_red_signal");
+    }
+
+    void LightListItem::set_cabin_a_head_light(const bool p_head_light) {
+        cabin_a.head_light = p_head_light;
+    }
+
+    bool LightListItem::get_cabin_a_head_light() const {
+        return cabin_a.head_light;
+    }
+
+    void LightListItem::set_cabin_a_left_white_signal(const bool p_left_white_signal) {
+        cabin_a.left_white_signal = p_left_white_signal;
+    }
+
+    bool LightListItem::get_cabin_a_left_white_signal() const {
+        return cabin_a.left_white_signal;
+    }
+
+    void LightListItem::set_cabin_a_left_red_signal(const bool p_left_red_signal) {
+        cabin_a.left_red_signal = p_left_red_signal;
+    }
+
+    bool LightListItem::get_cabin_a_left_red_signal() const {
+        return cabin_a.left_red_signal;
+    }
+
+    void LightListItem::set_cabin_a_right_white_signal(const bool p_right_white_signal) {
+        cabin_a.right_white_signal = p_right_white_signal;
+    }
+
+    bool LightListItem::get_cabin_a_right_white_signal() const {
+        return cabin_a.right_white_signal;
+    }
+
+    void LightListItem::set_cabin_a_right_red_signal(const bool p_right_red_signal) {
+        cabin_a.right_red_signal = p_right_red_signal;
+    }
+
+    bool LightListItem::get_cabin_a_right_red_signal() const {
+        return cabin_a.right_red_signal;
+    }
+
+    void LightListItem::set_cabin_b_head_light(const bool p_head_light) {
+        cabin_b.head_light = p_head_light;
+    }
+
+    bool LightListItem::get_cabin_b_head_light() const {
+        return cabin_b.head_light;
+    }
+
+    void LightListItem::set_cabin_b_left_white_signal(const bool p_left_white_signal) {
+        cabin_b.left_white_signal = p_left_white_signal;
+    }
+
+    bool LightListItem::get_cabin_b_left_white_signal() const {
+        return cabin_b.left_white_signal;
+    }
+
+    void LightListItem::set_cabin_b_left_red_signal(const bool p_left_red_signal) {
+        cabin_b.left_red_signal = p_left_red_signal;
+    }
+
+    bool LightListItem::get_cabin_b_left_red_signal() const {
+        return cabin_b.left_red_signal;
+    }
+
+    void LightListItem::set_cabin_b_right_white_signal(const bool p_right_white_signal) {
+        cabin_b.right_white_signal = p_right_white_signal;
+    }
+
+    bool LightListItem::get_cabin_b_right_white_signal() const {
+        return cabin_b.right_white_signal;
+    }
+
+    void LightListItem::set_cabin_b_right_red_signal(const bool p_right_red_signal) {
+        cabin_b.right_red_signal = p_right_red_signal;
+    }
+
+    bool LightListItem::get_cabin_b_right_red_signal() const {
+        return cabin_b.right_red_signal;
+    }
+} // namespace godot

--- a/src/resources/lighting/LightListItem.hpp
+++ b/src/resources/lighting/LightListItem.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <godot_cpp/classes/resource.hpp>
+
+namespace godot {
+    class LightListItem : public Resource {
+            GDCLASS(LightListItem, Resource);
+
+        public:
+            static void _bind_methods();
+            void set_cabin_a_head_light(bool p_head_light);
+            bool get_cabin_a_head_light() const;
+            void set_cabin_a_left_white_signal(bool p_left_white_signal);
+            bool get_cabin_a_left_white_signal() const;
+            void set_cabin_a_left_red_signal(bool p_left_red_signal);
+            bool get_cabin_a_left_red_signal() const;
+            void set_cabin_a_right_white_signal(bool p_right_white_signal);
+            bool get_cabin_a_right_white_signal() const;
+            void set_cabin_a_right_red_signal(bool p_right_red_signal);
+            bool get_cabin_a_right_red_signal() const;
+            void set_cabin_b_head_light(bool p_head_light);
+            bool get_cabin_b_head_light() const;
+            void set_cabin_b_left_white_signal(bool p_left_white_signal);
+            bool get_cabin_b_left_white_signal() const;
+            void set_cabin_b_left_red_signal(bool p_left_red_signal);
+            bool get_cabin_b_left_red_signal() const;
+            void set_cabin_b_right_white_signal(bool p_right_white_signal);
+            bool get_cabin_b_right_white_signal() const;
+            void set_cabin_b_right_red_signal(bool p_right_red_signal);
+            bool get_cabin_b_right_red_signal() const;
+
+            struct CabinLights {
+                bool head_light = false;
+                bool left_white_signal = false;
+                bool left_red_signal = false;
+                bool right_white_signal = false;
+                bool right_red_signal = false;
+            } cabin_a, cabin_b;
+
+    };
+} // namespace godot


### PR DESCRIPTION
Implements:
Light .fiz section
LightList .fiz section
HeadLights .fiz section
Implements `increase/decrease_light_selector_position` commands
Adds our own `TrainEngine::EngineType` Enumerator to replace `TEngineType` since Godot is not compatible with `TEngineType`'s `enum class` and this is acutally required by Light section implementation

Side note: I saw in those files changed line breaks between operators etc. so I'd suggest putting something like `max line length` in `.editorconfig` to avoid unnecessary diffs caused by that in the future