### PR TITLE
Add support for SteamAudio

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
   build-windows:
     strategy:
       matrix:
-        arch: [x86_64, x86_32]
+        arch: [x86_64]
         target: [template_debug]
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +54,7 @@ jobs:
   build-linux:
     strategy:
       matrix:
-        arch: [x86_64, x86_32]
+        arch: [x86_64]
         target: [template_debug]
     runs-on: ubuntu-latest
     steps:
@@ -100,7 +100,7 @@ jobs:
   build-android:
     strategy:
       matrix:
-        arch: [x86_64, x86_32, arm64, arm32]
+        arch: [x86_64, arm64]
         target: [template_debug]
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ CMakeLists.txt
 /demo/.godot/
 /demo/addons/gut
 /demo/addons/libmaszyna
+/demo/addons/godot-steam-audio
 /demo/bin
 /src/gen/
 /doc

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ scons platform=android arch=[x86|x86_64|armv7|armv8] target=[template_release|te
 | Plugin Version | Godot Engine version | Windows | Linux | Mac OS | Android                  | iOS | C++ Standard | MaSzyna Version |
 |----------------|----------------------|---------|-------|--------|--------------------------|-----|--------------|-----------------|
 | 25.08.2024     | 4.3                  | ✅       | ✅     | ❌      | ✅ (Target API Level: 34) | ❌   | C++ 17       | 24.06           |
-| 11.04.2025     | 4.4                  | ✅       | ✅     | ❌      | ✅ (Target API Level: 34) | ❌   | C++ 17       | 24.06           |
+| 11.03.2025     | 4.4                  | ✅       | ✅     | ❌      | ✅ (Target API Level: 34) | ❌   | C++ 17       | 24.06           |
+| 22.05.2025     | 4.4                  | ✅       | ✅     | ❌      | ❌                        | ❌   | C++ 17       | 24.06           |
 ### Documentation
 
 Project documentation: https://maszyna-reloaded.github.io/MaSzyna-API-wrapper/

--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,7 @@
  #!/usr/bin/env python
 import os
+import urllib.request
+import zipfile
 
 from SCons.Script import (  # pylint: disable=no-name-in-module
     Variables,
@@ -15,6 +17,17 @@ from SCons.Script import (  # pylint: disable=no-name-in-module
 )
 
 from SCons.Errors import UserError
+
+extract_dir = "vendor/godot-steam-audio"
+if not os.path.exists(extract_dir):
+    print(f"Downloading godot-steam-audio binaries...")
+    url = "https://github.com/stechyo/godot-steam-audio/releases/download/0.3.0/godot-steam-audio-v0.3.0.zip"
+
+    zip_path, _ = urllib.request.urlretrieve(url)
+    with zipfile.ZipFile(zip_path, "r") as f:
+        f.extractall(extract_dir)
+else:
+    print(f"godot-steam-audio binaries detected, skipping install...")
 
 
 def normalize_path(val, _env):
@@ -155,10 +168,16 @@ if os.path.exists("src") and sources:
         Copy("$TARGET", "$SOURCE"),
     )
 
+    copy_godot_steam_audio_to_project = env.Command(
+        os.path.join(projectdir, "addons", "godot-steam-audio"),
+        os.path.join("vendor", "godot-steam-audio", "addons", "godot-steam-audio"),
+        Copy("$TARGET", "$SOURCE"),    )
+
     commands += [
         library,
         copy_bin_to_project,
         copy_gut_framework_to_project,
+        copy_godot_steam_audio_to_project
     ]
 
     if not os.path.exists(addons_dst_path):

--- a/addons/libmaszyna/cabin/cabin_button.gd
+++ b/addons/libmaszyna/cabin/cabin_button.gd
@@ -59,10 +59,16 @@ var _t:float = 0.0
 
 var _enabled:bool = true
 var _setup_phase:bool = true
-var _sound:AudioStreamPlayer3D = AudioStreamPlayer3D.new()
+var _sound:SteamAudioPlayer = SteamAudioPlayer.new()
 
 func _ready():
     add_child(_sound)
+    _sound.distance_attenuation = true
+    _sound.air_absorption = true
+    _sound.occlusion = true
+    _sound.reflection = true
+    _sound.emission_angle_enabled = true
+    _sound.doppler_tracking = AudioStreamPlayer3D.DOPPLER_TRACKING_PHYSICS_STEP
     _sound.max_distance = sound_max_distance
     connect("pushed_changed", self._on_pushed_changed)
     controller_changed.connect(_update_state)

--- a/addons/libmaszyna/cabin/cabin_knob.gd
+++ b/addons/libmaszyna/cabin/cabin_knob.gd
@@ -52,7 +52,7 @@ var _target_mesh_position:Vector3 = Vector3.ZERO
 var _current_rotation:Vector3 = Vector3.ZERO
 var _current_position:Vector3 = Vector3.ZERO
 
-var _sound:AudioStreamPlayer3D = AudioStreamPlayer3D.new()
+var _sound:SteamAudioPlayer = SteamAudioPlayer.new()
 
 var _t = 0.0
 var _value_normalized = 0.0
@@ -75,6 +75,12 @@ func _update_state():
         _target_mesh_rotation = mesh_rotation * _value_normalized
 
 func _ready():
+    _sound.distance_attenuation = true
+    _sound.air_absorption = true
+    _sound.occlusion = true
+    _sound.reflection = true
+    _sound.emission_angle_enabled = true
+    _sound.doppler_tracking = AudioStreamPlayer3D.DOPPLER_TRACKING_PHYSICS_STEP
     if not Engine.is_editor_hint() and Console:
         Console.console_toggled.connect(_on_console_toggle)
     controller_changed.connect(_update_state)

--- a/addons/libmaszyna/cabin/cabin_switch.gd
+++ b/addons/libmaszyna/cabin/cabin_switch.gd
@@ -80,13 +80,19 @@ var _target_mesh_position:Vector3 = Vector3.ZERO
 var _current_rotation:Vector3 = Vector3.ZERO
 var _current_position:Vector3 = Vector3.ZERO
 
-var _sound:AudioStreamPlayer3D = AudioStreamPlayer3D.new()
+var _sound:SteamAudioPlayer = SteamAudioPlayer.new()
 var _handle_actions:bool = true
 var _t:float = 0.0
 var _setup_phase:bool = true
 
 func _ready():
     add_child(_sound)
+    _sound.distance_attenuation = true
+    _sound.air_absorption = true
+    _sound.occlusion = true
+    _sound.reflection = true
+    _sound.emission_angle_enabled = true
+    _sound.doppler_tracking = AudioStreamPlayer3D.DOPPLER_TRACKING_PHYSICS_STEP
     _sound.max_distance = sound_max_distance
     self.switch_position_changed.connect(self._on_switch_position_changed)
 

--- a/addons/libmaszyna/sound/train_sound_3d.gd
+++ b/addons/libmaszyna/sound/train_sound_3d.gd
@@ -1,4 +1,4 @@
-extends AudioStreamPlayer3D
+extends SteamAudioPlayer
 class_name TrainSound3D
 
 @export var state_property = ""
@@ -13,6 +13,13 @@ var _dirty = false
 var _train = null
 var _should_play = false
 
+func _ready() -> void: 
+    self.distance_attenuation = true
+    self.air_absorption = true
+    self.occlusion = true
+    self.reflection = true
+    self.emission_angle_enabled = true
+    self.doppler_tracking = AudioStreamPlayer3D.DOPPLER_TRACKING_PHYSICS_STEP
 
 func _process(_delta):
     _t += _delta

--- a/demo/default_bus_layout.tres
+++ b/demo/default_bus_layout.tres
@@ -1,0 +1,9 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://bq07s7heaqfrr"]
+
+[resource]
+bus/1/name = &"old_cabin_switches"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = -0.301591
+bus/1/send = &"Master"

--- a/demo/demo_3d.tscn
+++ b/demo/demo_3d.tscn
@@ -349,5 +349,7 @@ script = ExtResource("4_drlsl")
 data_path = "models/kolejowe"
 model_filename = "klamoty_naprawcze"
 
+[node name="SteamAudioConfig" type="SteamAudioConfig" parent="."]
+
 [connection signal="fadein_finished" from="LoadingScreen" to="." method="_on_loading_screen_fadein_finished"]
 [connection signal="visibility_changed" from="UserSettingsPanel" to="." method="_on_user_settings_panel_visibility_changed"]

--- a/demo/vehicles/sm42/sm_42.tscn
+++ b/demo/vehicles/sm42/sm_42.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=6 format=3 uid="uid://bcxtf08c2yqx4"]
+[gd_scene load_steps=7 format=3 uid="uid://bcxtf08c2yqx4"]
 
 [ext_resource type="Script" uid="uid://bmsduesjycv2v" path="res://addons/libmaszyna/rail_vehicle_3d.gd" id="1_iiqbf"]
 [ext_resource type="PackedScene" uid="uid://do3s7mkbpv7es" path="res://vehicles/sm42/sm_42_cabin.tscn" id="2_htu7b"]
 [ext_resource type="PackedScene" uid="uid://c5hi8nsm1d2hb" path="res://vehicles/sm42/sm_42v_1.tscn" id="3_vuhlb"]
 [ext_resource type="Script" uid="uid://dgifxvb2e4hww" path="res://addons/libmaszyna/e3d/e3d_model_instance.gd" id="4_c88oy"]
+[ext_resource type="SteamAudioMaterial" uid="uid://cqx8833t2v8mo" path="res://addons/godot-steam-audio/materials/metal_material.tres" id="5_n7ime"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_uljbo"]
-size = Vector3(4.5332, 4.72223, 17.0549)
+size = Vector3(2.67932, 4.72223, 13.9419)
 
 [node name="SM42-099" type="Node3D"]
 transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, 0)
@@ -67,8 +68,12 @@ exclude_node_names = ["cien"]
 monitoring = false
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.53125, 1.97558, 0.243691)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0164261, 1.97558, 0.172673)
 shape = SubResource("BoxShape3D_uljbo")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D"]
+material = ExtResource("5_n7ime")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0164261, -1.97558, -0.172673)
 
 [node name="401W-1" type="VisualInstance3D" parent="."]
 _import_path = NodePath("")

--- a/demo/vehicles/sm42/sm_42_cabin.tscn
+++ b/demo/vehicles/sm42/sm_42_cabin.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=54 format=3 uid="uid://do3s7mkbpv7es"]
+[gd_scene load_steps=60 format=3 uid="uid://do3s7mkbpv7es"]
 
 [ext_resource type="Script" uid="uid://dgifxvb2e4hww" path="res://addons/libmaszyna/e3d/e3d_model_instance.gd" id="1_6k4j1"]
 [ext_resource type="Script" uid="uid://fi23qlrohins" path="res://vehicles/sm42/sm_42_cabin.gd" id="1_bffp8"]
 [ext_resource type="Script" uid="uid://cmmb3s07th3xp" path="res://addons/libmaszyna/sound/maszyna_audio_stream.gd" id="7_lbg33"]
 [ext_resource type="Script" uid="uid://blbw51qwvmbue" path="res://addons/libmaszyna/sound/train_sound_3d.gd" id="15_df5xj"]
+[ext_resource type="SteamAudioMaterial" uid="uid://cqx8833t2v8mo" path="res://addons/godot-steam-audio/materials/metal_material.tres" id="16_mu6ha"]
 [ext_resource type="PackedScene" uid="uid://djl581jijicpq" path="res://addons/libmaszyna/cabin/cabin_command.tscn" id="66_epgva"]
 [ext_resource type="Script" uid="uid://c4lj08dvqxvhn" path="res://addons/libmaszyna/cabin/cabin_gauge.gd" id="67_fryen"]
 [ext_resource type="PackedScene" uid="uid://cfj82gn1nfl36" path="res://addons/libmaszyna/cabin/cabin_gauge.tscn" id="68_g4w65"]
@@ -206,6 +207,21 @@ script = ExtResource("7_lbg33")
 file_path = "20786_control_6d_6"
 loop = false
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_mu6ha"]
+size = Vector3(1.50269, 0.378967, 0.191788)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_wwe3j"]
+size = Vector3(1.60795, 1.13485, 0.850833)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_4hnq2"]
+size = Vector3(0.255966, 0.205078, 0.0754242)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_myls2"]
+size = Vector3(2.83954, 1.6886, 0.16748)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_lo85d"]
+size = Vector3(2.97583, 0.341797, 1.48938)
+
 [node name="SM42Cabin" type="Node3D"]
 script = ExtResource("1_bffp8")
 camera_bound_min = Vector3(-1.65, 1.8, -3.4)
@@ -234,19 +250,42 @@ script = ExtResource("1_6k4j1")
 data_path = "/dynamic/pkp/sm42_v1"
 model_filename = "6da_kabina"
 
-[node name="Buzzer" type="AudioStreamPlayer3D" parent="."]
+[node name="Buzzer" type="SteamAudioPlayer" parent="."]
+distance_attenuation = true
+air_absorption = true
+reflection = true
 transform = Transform3D(0.999125, -0.0128957, 0.0397967, 0, 0.951302, 0.30826, -0.0418339, -0.30799, 0.950469, -0.988872, 2.80983, 2.49681)
 stream = SubResource("AudioStream_hwnyj")
+attenuation_model = 3
+panning_strength = 0.0
+emission_angle_enabled = true
+doppler_tracking = 2
 script = ExtResource("15_df5xj")
 state_property = "beeping"
 
-[node name="AlerterLightOn" type="AudioStreamPlayer3D" parent="."]
+[node name="AlerterLightOn" type="SteamAudioPlayer" parent="."]
+distance_attenuation = true
+min_attenuation_distance = 10.0
+air_absorption = true
+air_absorption_model = 1
+reflection = true
 transform = Transform3D(0.991105, -0.0399184, 0.126957, 0, 0.953956, 0.299946, -0.133085, -0.297278, 0.94547, 0.704235, 3.06481, 2.01449)
 stream = SubResource("AudioStream_ii5lq")
+attenuation_model = 3
+panning_strength = 0.0
+emission_angle_enabled = true
+doppler_tracking = 2
 
-[node name="AlerterLightOff" type="AudioStreamPlayer3D" parent="."]
+[node name="AlerterLightOff" type="SteamAudioPlayer" parent="."]
+distance_attenuation = true
+air_absorption = true
+reflection = true
 transform = Transform3D(0.991105, -0.0399184, 0.126957, 0, 0.953956, 0.299946, -0.133085, -0.297278, 0.94547, 0.704235, 3.06481, 2.01449)
 stream = SubResource("AudioStream_xhr6w")
+attenuation_model = 3
+panning_strength = 0.0
+emission_angle_enabled = true
+doppler_tracking = 2
 
 [node name="Commands" type="Node" parent="."]
 
@@ -668,5 +707,42 @@ light_energy_on = 0.2
 transform = Transform3D(0.997974, -0.0455378, 0.0444316, 0, 0.698359, 0.715747, -0.0636228, -0.714297, 0.696945, -0.0587103, 3.1026, 2.18974)
 state_property = "blinking"
 target_path = NodePath("../../Cabin/banan/podloga_glowna/czuwak_on")
+
+[node name="Area3D" type="Area3D" parent="."]
+
+[node name="CollisionShape3D2" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.00912553, 3.11785, -1.93609)
+shape = SubResource("BoxShape3D_mu6ha")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D2"]
+material = ExtResource("16_mu6ha")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0421133, 2.37393, -2.15335)
+shape = SubResource("BoxShape3D_wwe3j")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D"]
+material = ExtResource("16_mu6ha")
+
+[node name="radio" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.562448, 2.69742, -2.6078)
+shape = SubResource("BoxShape3D_4hnq2")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/radio"]
+material = ExtResource("16_mu6ha")
+
+[node name="CollisionShape3D3" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.000213623, 2.52089, -3.83724)
+shape = SubResource("BoxShape3D_myls2")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D3"]
+material = ExtResource("16_mu6ha")
+
+[node name="CollisionShape3D4" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.069458, 1.68179, -3.14416)
+shape = SubResource("BoxShape3D_lo85d")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D4"]
+material = ExtResource("16_mu6ha")
 
 [connection signal="blink" from="Lights/Czuwak" to="." method="_on_czuwak_blink"]

--- a/demo/vehicles/tem2/tem2.tscn
+++ b/demo/vehicles/tem2/tem2.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=20 format=3 uid="uid://xh8isp1j28uj"]
+[gd_scene load_steps=21 format=3 uid="uid://xh8isp1j28uj"]
 
 [ext_resource type="Script" uid="uid://bmsduesjycv2v" path="res://addons/libmaszyna/rail_vehicle_3d.gd" id="1_ra284"]
 [ext_resource type="PackedScene" uid="uid://dwcx6807obsgm" path="res://vehicles/tem2/tem2_cabin.tscn" id="2_nt307"]
 [ext_resource type="Script" uid="uid://dgifxvb2e4hww" path="res://addons/libmaszyna/e3d/e3d_model_instance.gd" id="2_q4wpc"]
+[ext_resource type="SteamAudioMaterial" uid="uid://cqx8833t2v8mo" path="res://addons/godot-steam-audio/materials/metal_material.tres" id="4_ah6qb"]
 [ext_resource type="Script" uid="uid://bbn3nd8ts8yjx" path="res://vehicles/sm42/sm_42v_1.gd" id="4_tujep"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_kol4m"]
@@ -188,6 +189,9 @@ monitoring = false
 [node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.53125, 1.97558, 0.243691)
 shape = SubResource("BoxShape3D_kol4m")
+
+[node name="SteamAudioDynamicGeometry" type="SteamAudioDynamicGeometry" parent="Area3D/CollisionShape3D"]
+material = ExtResource("4_ah6qb")
 
 [node name="TEM2Controller" type="TrainController" parent="."]
 train_id = "tem2"


### PR DESCRIPTION
Adds support for SteamAudio using the godot-steam-audio plugin
Support added is still very basic but could provide a nice base for future bigger implementations which should add auto-generating collision meshes for SteamAudio geometry