### PR TITLE
Use the power of macros to remove binding boilerplate

### DIFF
--- a/demo/tests/sm42_controller.tscn
+++ b/demo/tests/sm42_controller.tscn
@@ -101,21 +101,21 @@ max_wakeup_voltage = 450.0
 max_wakeup_power = 490.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_210ku"]
-mfi = 17.567
-mIsat = 64.0
-fi = 1500.0
-Isat = 15.0
+voltage_constant_multiplier = 17.567
+saturation_current_multiplier = 64.0
+voltage_constant = 1500.0
+saturation_current = 15.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_ewrnx"]
-mfi = 15.0
-mIsat = 183.3
-fi = 2000.0
-Isat = 49.0
+voltage_constant_multiplier = 15.0
+saturation_current_multiplier = 183.3
+voltage_constant = 2000.0
+saturation_current = 49.0
 
 [node name="SM42v1" type="TrainController"]
 train_id = "TestTrain"
 type_name = "6d"
-dimensions/mass = 74000.0
+mass = 74000.0
 power = 590.0
 max_velocity = 90.0
 axle_arrangement = "Bo'Bo'"
@@ -126,30 +126,30 @@ script = ExtResource("1_vib8j")
 valve/type = 20
 friction_elements_per_axle = 4
 brake_force/max = 85.0
-max_pressures/cylinder = 4.0
-max_pressures/antislip = 1.8
-cylinders/count = 4
-cylinders/radius = 0.114
-cylinders/distance = 0.05
-cylinders/gear_ratio = 6.68
+max_cylinder_pressure = 4.0
+max_antislip_pressure = 1.8
+cylinder/count = 4
+cylinder/radius = 0.114
+cylinder/distance = 0.05
+cylinder/gear_ratio = 6.68
 tank/volume_main = 0.8
 tank/volume_aux = 200.0
-compressor/pressure_min = 7.0
-compressor/pressure_max = 8.0
+compressor/cab_a/min_pressure = 7.0
+compressor/cab_a/max_pressure = 8.0
 compressor/speed = 0.057
 compressor/power = 3
 rig_effectiveness = 0.85
 
 [node name="StonkaDieselEngine" type="TrainDieselElectricEngine" parent="."]
 oil_pump/pressure_minimum = 0.15
-Ftmax = 228000.0
+maximum_traction_force = 228000.0
 wwlist = Array[WWListItem]([SubResource("WWListItem_tqpff"), SubResource("WWListItem_083b8"), SubResource("WWListItem_0r5q0"), SubResource("WWListItem_vjhrb"), SubResource("WWListItem_6sfix"), SubResource("WWListItem_jxcvy"), SubResource("WWListItem_q4qj4"), SubResource("WWListItem_p5gw0"), SubResource("WWListItem_laio0"), SubResource("WWListItem_qppya"), SubResource("WWListItem_65frr"), SubResource("WWListItem_e4rmd")])
 motor_param_table = Array[MotorParameter]([SubResource("MotorParameter_210ku"), SubResource("MotorParameter_ewrnx")])
 
 [node name="TrainSecuritySystem" type="TrainSecuritySystem" parent="."]
 aware_system/active = true
 aware_delay = 60.0
-emergency_brake_delay = 2.5
+emergency_brake/delay = 2.5
 sound_signal_delay = 2.5
 shp_magnet_distance = 3.0
 ca_max_hold_time = 1.0

--- a/demo/vehicles/sm42/sm_42v_1.tscn
+++ b/demo/vehicles/sm42/sm_42v_1.tscn
@@ -102,16 +102,16 @@ max_wakeup_voltage = 450.0
 max_wakeup_power = 490.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_210ku"]
-mfi = 17.567
-mIsat = 64.0
-fi = 1500.0
-Isat = 15.0
+voltage_constant_multiplier = 17.567
+saturation_current_multiplier = 64.0
+voltage_constant = 1500.0
+saturation_current = 15.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_ewrnx"]
-mfi = 15.0
-mIsat = 183.3
-fi = 2000.0
-Isat = 49.0
+voltage_constant_multiplier = 15.0
+saturation_current_multiplier = 183.3
+voltage_constant = 2000.0
+saturation_current = 49.0
 
 [sub_resource type="LightListItem" id="LightListItem_ss4tc"]
 cabin_a/head_light = true
@@ -121,7 +121,7 @@ cabin_a/right/white_signal = true
 [node name="SM42v1" type="TrainController"]
 train_id = "sm42v1"
 type_name = "6d"
-dimensions/mass = 74000.0
+mass = 74000.0
 power = 590.0
 max_velocity = 90.0
 axle_arrangement = "Bo'Bo'"
@@ -132,30 +132,30 @@ script = ExtResource("1_vib8j")
 valve/type = 20
 friction_elements_per_axle = 4
 brake_force/max = 85.0
-max_pressures/cylinder = 4.0
-max_pressures/antislip = 1.8
-cylinders/count = 4
-cylinders/radius = 0.114
-cylinders/distance = 0.05
-cylinders/gear_ratio = 6.68
+max_cylinder_pressure = 4.0
+max_antislip_pressure = 1.8
+cylinder/count = 4
+cylinder/radius = 0.114
+cylinder/distance = 0.05
+cylinder/gear_ratio = 6.68
 tank/volume_main = 0.8
 tank/volume_aux = 200.0
-compressor/pressure_min = 7.0
-compressor/pressure_max = 8.0
+compressor/cab_a/min_pressure = 7.0
+compressor/cab_a/max_pressure = 8.0
 compressor/speed = 0.057
 compressor/power = 3
 rig_effectiveness = 0.85
 
 [node name="StonkaDieselEngine" type="TrainDieselElectricEngine" parent="."]
 oil_pump/pressure_minimum = 0.15
-Ftmax = 228000.0
+maximum_traction_force = 228000.0
 wwlist = Array[WWListItem]([SubResource("WWListItem_tqpff"), SubResource("WWListItem_083b8"), SubResource("WWListItem_0r5q0"), SubResource("WWListItem_vjhrb"), SubResource("WWListItem_6sfix"), SubResource("WWListItem_jxcvy"), SubResource("WWListItem_q4qj4"), SubResource("WWListItem_p5gw0"), SubResource("WWListItem_laio0"), SubResource("WWListItem_qppya"), SubResource("WWListItem_65frr"), SubResource("WWListItem_e4rmd")])
 motor_param_table = Array[MotorParameter]([SubResource("MotorParameter_210ku"), SubResource("MotorParameter_ewrnx")])
 
 [node name="TrainSecuritySystem" type="TrainSecuritySystem" parent="."]
 aware_system/active = true
 aware_delay = 60.0
-emergency_brake_delay = 2.5
+emergency_brake/delay = 2.5
 sound_signal_delay = 2.5
 shp_magnet_distance = 3.0
 ca_max_hold_time = 1.0

--- a/demo/vehicles/tem2/tem2.tscn
+++ b/demo/vehicles/tem2/tem2.tscn
@@ -119,16 +119,16 @@ max_wakeup_voltage = 450.0
 max_wakeup_power = 490.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_l4x0r"]
-mfi = 17.567
-mIsat = 64.0
-fi = 1500.0
-Isat = 15.0
+voltage_constant_multiplier = 17.567
+saturation_current_multiplier = 64.0
+voltage_constant = 1500.0
+saturation_current = 15.0
 
 [sub_resource type="MotorParameter" id="MotorParameter_374xt"]
-mfi = 15.0
-mIsat = 183.3
-fi = 2000.0
-Isat = 49.0
+voltage_constant_multiplier = 15.0
+saturation_current_multiplier = 183.3
+voltage_constant = 2000.0
+saturation_current = 49.0
 
 [node name="TEM2" type="Node3D"]
 script = ExtResource("1_ra284")
@@ -196,7 +196,7 @@ material = ExtResource("4_ah6qb")
 [node name="TEM2Controller" type="TrainController" parent="."]
 train_id = "tem2"
 type_name = "tem2"
-dimensions/mass = 116000.0
+mass = 116000.0
 power = 780.0
 max_velocity = 90.0
 axle_arrangement = "Bo'Bo'"
@@ -207,16 +207,16 @@ script = ExtResource("4_tujep")
 valve/type = 20
 friction_elements_per_axle = 4
 brake_force/max = 85.0
-max_pressures/cylinder = 4.0
-max_pressures/antislip = 1.8
-cylinders/count = 4
-cylinders/radius = 0.114
-cylinders/distance = 0.05
-cylinders/gear_ratio = 6.68
+max_cylinder_pressure = 4.0
+max_antislip_pressure = 1.8
+cylinder/count = 4
+cylinder/radius = 0.114
+cylinder/distance = 0.05
+cylinder/gear_ratio = 6.68
 tank/volume_main = 0.8
 tank/volume_aux = 200.0
-compressor/pressure_min = 7.0
-compressor/pressure_max = 8.0
+compressor/cab_a/min_pressure = 7.0
+compressor/cab_a/max_pressure = 8.0
 compressor/speed = 0.057
 compressor/power = 3
 rig_effectiveness = 0.85
@@ -224,14 +224,14 @@ rig_effectiveness = 0.85
 [node name="DieselEngine" type="TrainDieselElectricEngine" parent="TEM2Controller"]
 oil_pump/pressure_minimum = 0.16
 oil_pump/pressure_maximum = 0.3
-Ftmax = 228000.0
+maximum_traction_force = 228000.0
 wwlist = Array[WWListItem]([SubResource("WWListItem_w7fy5"), SubResource("WWListItem_j7m6u"), SubResource("WWListItem_w1qdg"), SubResource("WWListItem_wk0d4"), SubResource("WWListItem_ndnpm"), SubResource("WWListItem_ye3f5"), SubResource("WWListItem_ljbq7"), SubResource("WWListItem_wnj0o"), SubResource("WWListItem_qwjcl"), SubResource("WWListItem_4li30"), SubResource("WWListItem_or38i"), SubResource("WWListItem_lwfur")])
 motor_param_table = Array[MotorParameter]([SubResource("MotorParameter_l4x0r"), SubResource("MotorParameter_374xt")])
 
 [node name="TrainSecuritySystem" type="TrainSecuritySystem" parent="TEM2Controller"]
 aware_system/active = true
 aware_delay = 60.0
-emergency_brake_delay = 2.5
+emergency_brake/delay = 2.5
 sound_signal_delay = 2.5
 shp_magnet_distance = 3.0
 ca_max_hold_time = 1.0

--- a/doc_classes/MotorParameter.xml
+++ b/doc_classes/MotorParameter.xml
@@ -9,32 +9,32 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="Isat" type="float" setter="set_Isat" getter="get_Isat" default="0.0">
-			Saturation current (A).
-		</member>
 		<member name="auto_switch" type="bool" setter="set_auto_switch" getter="get_auto_switch" default="false">
 			If [code]true[/code], enables automatic switching.
 		</member>
-		<member name="fi" type="float" setter="set_fi" getter="get_fi" default="0.0">
-			Voltage constant (V/rpm). Used in the approximation of back EMF (E) as a function of speed (n): E(n) = fi * n. For diesel engines, this represents the speed at the current gear ratio.
-		</member>
-		<member name="fi0" type="float" setter="set_fi0" getter="get_fi0" default="0.0">
+		<member name="initial_voltage_constant" type="float" setter="set_initial_voltage_constant" getter="get_initial_voltage_constant" default="0.0">
 			Initial voltage constant (V/rpm). For diesel engines, this represents the speed at the initial gear ratio.
 		</member>
-		<member name="mIsat" type="float" setter="set_mIsat" getter="get_mIsat" default="0.0">
+		<member name="initial_voltage_constant_multiplier" type="float" setter="set_initial_voltage_constant_multiplier" getter="get_initial_voltage_constant_multiplier" default="0.0">
+			Initial value for the voltage constant multiplier. This suggests that the motor might have different parameters depending on its state or operating mode. This parameter is linked to the gear ratio in diesel engines.
+		</member>
+		<member name="saturation_current" type="float" setter="set_saturation_current" getter="get_saturation_current" default="0.0">
+			Saturation current (A).
+		</member>
+		<member name="saturation_current_multiplier" type="float" setter="set_saturation_current_multiplier" getter="get_saturation_current_multiplier" default="0.0">
 			Saturation current multiplier. For diesel engines, this is equal to the gear ratio.
-		</member>
-		<member name="mfi" type="float" setter="set_mfi" getter="get_mfi" default="0.0">
-			Voltage constant multiplier. For diesel engines, this represents the speed at the current gear ratio.
-		</member>
-		<member name="mfi0" type="float" setter="set_mfi0" getter="get_mfi0" default="0.0">
-			Initial value for the voltage constant multiplier ([i]mfi[/i]). This suggests that the motor might have different parameters depending on its state or operating mode. This parameter is linked to the gear ratio in diesel engines.
 		</member>
 		<member name="shunting_down" type="float" setter="set_shunting_down" getter="get_shunting_down" default="0.0">
 			Shunting down value.
 		</member>
 		<member name="shunting_up" type="float" setter="set_shunting_up" getter="get_shunting_up" default="0.0">
 			Shunting up value.
+		</member>
+		<member name="voltage_constant" type="float" setter="set_voltage_constant" getter="get_voltage_constant" default="0.0">
+			Voltage constant (V/rpm). Used in the approximation of back EMF (E) as a function of speed (n): E(n) = fi * n. For diesel engines, this represents the speed at the current gear ratio.
+		</member>
+		<member name="voltage_constant_multiplier" type="float" setter="set_voltage_constant_multiplier" getter="get_voltage_constant_multiplier" default="0.0">
+			Voltage constant multiplier. For diesel engines, this represents the speed at the current gear ratio.
 		</member>
 	</members>
 </class>

--- a/doc_classes/TrainBrake.xml
+++ b/doc_classes/TrainBrake.xml
@@ -55,63 +55,68 @@
 			[code]Brake:MBF[/code]
 			Maximum braking force to the selected value
 		</member>
-		<member name="brake_force/track" type="float" setter="set_track_brake_force" getter="get_track_brake_force" default="0.0">
+		<member name="brake_force/traction" type="float" setter="set_traction_brake_force" getter="get_traction_brake_force" default="0.0">
 			[code]Brake:TBF[/code]
+		</member>
+		<member name="compressor/cab_a/max_pressure" type="float" setter="set_compressor_pressure_cab_a_max" getter="get_compressor_pressure_cab_a_max" default="0.0">
+			[code]Brake:MaxCP[/code]
+		</member>
+		<member name="compressor/cab_a/min_pressure" type="float" setter="set_compressor_pressure_cab_a_min" getter="get_compressor_pressure_cab_a_min" default="0.0">
+			[code]Brake:MinCP[/code]
+		</member>
+		<member name="compressor/cab_b/max_pressure" type="float" setter="set_compressor_pressure_cab_b_max" getter="get_compressor_pressure_cab_b_max" default="0.0">
+			[code]Brake:MaxCP_B[/code]
+		</member>
+		<member name="compressor/cab_b/min_pressure" type="float" setter="set_compressor_pressure_cab_b_min" getter="get_compressor_pressure_cab_b_min" default="0.0">
+			[code]Brake:MinCP_B[/code]
 		</member>
 		<member name="compressor/power" type="int" setter="set_compressor_power" getter="get_compressor_power" enum="TrainBrake.CompressorPower" default="0">
 			[code]Brake:CompressorPower[/code]
 		</member>
-		<member name="compressor/pressure_cab_b_max" type="float" setter="set_compressor_pressure_cab_b_max" getter="get_compressor_pressure_cab_b_max" default="0.0">
-			[code]Brake:MaxCP_B[/code]
-		</member>
-		<member name="compressor/pressure_cab_b_min" type="float" setter="set_compressor_pressure_cab_b_min" getter="get_compressor_pressure_cab_b_min" default="0.0">
-			[code]Brake:MinCP_B[/code]
-		</member>
-		<member name="compressor/pressure_max" type="float" setter="set_compressor_pressure_max" getter="get_compressor_pressure_max" default="0.0">
-			[code]Brake:MaxCP[/code]
-		</member>
-		<member name="compressor/pressure_min" type="float" setter="set_compressor_pressure_min" getter="get_compressor_pressure_min" default="0.0">
-			[code]Brake:MinCP[/code]
-		</member>
 		<member name="compressor/speed" type="float" setter="set_compressor_speed" getter="get_compressor_speed" default="0.0">
 			[code]Brake:CompressorSpeed[/code]
 		</member>
-		<member name="cylinders/count" type="int" setter="set_cylinders_count" getter="get_cylinders_count" default="0">
+		<member name="cylinder/count" type="int" setter="set_cylinder_count" getter="get_cylinder_count" default="0">
 			[code]Brake:BCN[/code]
 		</member>
-		<member name="cylinders/distance" type="float" setter="set_cylinder_distance" getter="get_cylinder_distance" default="0.0">
+		<member name="cylinder/distance" type="float" setter="set_cylinder_distance" getter="get_cylinder_distance" default="0.0">
 			[code]Brake:BCD[/code]
 		</member>
-		<member name="cylinders/gear_ratio" type="float" setter="set_cylinder_gear_ratio" getter="get_cylinder_gear_ratio" default="0.0">
+		<member name="cylinder/gear_ratio" type="float" setter="set_cylinder_gear_ratio" getter="get_cylinder_gear_ratio" default="0.0">
 			[code]Brake:BCM[/code]
 		</member>
-		<member name="cylinders/gear_ratio_high" type="float" setter="set_cylinder_gear_ratio_high" getter="get_cylinder_gear_ratio_high" default="0.0">
+		<member name="cylinder/gear_ratio_high" type="float" setter="set_cylinder_gear_ratio_high" getter="get_cylinder_gear_ratio_high" default="0.0">
 			[code]Brake:BCMHi[/code]
 		</member>
-		<member name="cylinders/gear_ratio_low" type="float" setter="set_cylinder_gear_ratio_low" getter="get_cylinder_gear_ratio_low" default="0.0">
+		<member name="cylinder/gear_ratio_low" type="float" setter="set_cylinder_gear_ratio_low" getter="get_cylinder_gear_ratio_low" default="0.0">
 			[code]Brake:BCMLo[/code]
 		</member>
-		<member name="cylinders/radius" type="float" setter="set_cylinder_radius" getter="get_cylinder_radius" default="0.0">
+		<member name="cylinder/radius" type="float" setter="set_cylinder_radius" getter="get_cylinder_radius" default="0.0">
 			[code]Brake:BCR[/code]
 		</member>
-		<member name="cylinders/spring_force" type="float" setter="set_cylinder_spring_force" getter="get_cylinder_spring_force" default="0.0">
+		<member name="cylinder/spring_force" type="float" setter="set_cylinder_spring_force" getter="get_cylinder_spring_force" default="0.0">
 			[code]Brake:BCS[/code]
+		</member>
+		<member name="est_valve/size" type="int" setter="set_est_valve_size" getter="get_est_valve_size" default="0">
+			[code]Brake:Size[/code]
+			Size of the ESt family camshaft valve
 		</member>
 		<member name="friction_elements_per_axle" type="int" setter="set_friction_elements_per_axle" getter="get_friction_elements_per_axle" default="1">
 			[code]Brake:NBpA[/code]
 		</member>
-		<member name="max_pressures/antislip" type="float" setter="set_max_antislip_pressure" getter="get_max_antislip_pressure" default="0.0">
+		<member name="max_antislip_pressure" type="float" setter="set_max_antislip_pressure" getter="get_max_antislip_pressure" default="0.0">
 			[code]Brake:MaxASBP[/code]
 		</member>
-		<member name="max_pressures/aux" type="float" setter="set_max_pressure_aux" getter="get_max_pressure_aux" default="0.0">
+		<member name="max_aux_pressure" type="float" setter="set_max_aux_pressure" getter="get_max_aux_pressure" default="0.0">
+			Maximum auxiliary pressure
 		</member>
-		<member name="max_pressures/cylinder" type="float" setter="set_max_pressure" getter="get_max_pressure" default="0.0">
+		<member name="max_cylinder_pressure" type="float" setter="set_max_cylinder_pressure" getter="get_max_cylinder_pressure" default="0.0">
 			[code]Brake:MaxBP[/code]
 		</member>
-		<member name="max_pressures/medium" type="float" setter="set_max_pressure_medium" getter="get_max_pressure_medium" default="0.0">
+		<member name="max_medium_pressure" type="float" setter="set_max_medium_pressure" getter="get_max_medium_pressure" default="0.0">
 			[code]Brake:MedMaxBP[/code]
 		</member>
-		<member name="max_pressures/tare" type="float" setter="set_max_pressure_tare" getter="get_max_pressure_tare" default="0.0">
+		<member name="max_tare_pressure" type="float" setter="set_max_tare_pressure" getter="get_max_tare_pressure" default="0.0">
 			[code]Brake:TareMaxBP[/code]
 		</member>
 		<member name="pipe/pressure_max" type="float" setter="set_pipe_pressure_max" getter="get_pipe_pressure_max" default="5.0">
@@ -120,11 +125,11 @@
 		<member name="pipe/pressure_min" type="float" setter="set_pipe_pressure_min" getter="get_pipe_pressure_min" default="3.5">
 			[code]Brake:LoPP[/code]
 		</member>
+		<member name="piston_stroke/adjuster_resistance" type="float" setter="set_piston_stroke_adjuster_resistance" getter="get_piston_stroke_adjuster_resistance" default="0.0">
+			[code]Brake:BSA[/code]
+		</member>
 		<member name="rig_effectiveness" type="float" setter="set_rig_effectiveness" getter="get_rig_effectiveness" default="0.0">
 			[code]Brake:BRE[/code]
-		</member>
-		<member name="slck/adjustment_force" type="float" setter="set_slck_adjustment_force" getter="get_slck_adjustment_force" default="0.0">
-			[code]Brake:BSA[/code]
 		</member>
 		<member name="tank/volume_aux" type="float" setter="set_aux_tank_volume" getter="get_aux_tank_volume" default="0.0">
 			[code]Brake:BVV[/code]
@@ -132,11 +137,7 @@
 		<member name="tank/volume_main" type="float" setter="set_main_tank_volume" getter="get_main_tank_volume" default="0.0">
 			[code]Brake:Vv[/code]
 		</member>
-		<member name="valve/est_size" type="int" setter="set_valve_size" getter="get_valve_size" default="0">
-			[code]Brake:Size[/code]
-			Size of the ESt family camshaft valve
-		</member>
-		<member name="valve/type" type="int" setter="set_valve" getter="get_valve" enum="TrainBrake.TrainBrakeValve" default="0">
+		<member name="valve/type" type="int" setter="set_valve_type" getter="get_valve_type" enum="TrainBrake.TrainBrakeValve" default="0">
 			[code]Brake:BrakeValve[/code]
 			Type of a brake valve
 		</member>

--- a/doc_classes/TrainController.xml
+++ b/doc_classes/TrainController.xml
@@ -133,7 +133,7 @@
 			Returns a dictionary with all config properties of the train.
 			This is a shortcut for iterating over [method TrainSystem.get_supported_config_properties] to read each from [method TrainSystem.get_config_property].
 		</member>
-		<member name="dimensions/mass" type="float" setter="set_mass" getter="get_mass" default="0.0">
+		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="0.0">
 			[code]Param.M[/code] Mass of the train
 		</member>
 		<member name="max_velocity" type="float" setter="set_max_velocity" getter="get_max_velocity" default="0.0">
@@ -142,16 +142,16 @@
 		<member name="power" type="float" setter="set_power" getter="get_power" default="0.0">
 			[code]Param.PWR[/code]
 		</member>
-		<member name="radio/channel_max" type="int" setter="set_radio_channel_max" getter="get_radio_channel_max" default="0">
+		<member name="radio_channel/max" type="int" setter="set_radio_channel_max" getter="get_radio_channel_max" default="0">
 			Maximum radio channel number
 		</member>
-		<member name="radio/channel_min" type="int" setter="set_radio_channel_min" getter="get_radio_channel_min" default="0">
+		<member name="radio_channel/min" type="int" setter="set_radio_channel_min" getter="get_radio_channel_min" default="0">
 			Minimum radio channel number
 		</member>
 		<member name="state" type="Dictionary" setter="" getter="get_state" default="{}">
 			Actual state of the train
 		</member>
-		<member name="train_id" type="String" setter="set_train_id" getter="get_train_id" default="&quot;train&quot;">
+		<member name="train_id" type="String" setter="set_train_id" getter="get_train_id" default="&quot;&quot;">
 			Unique identifier of the train. See [method TrainSystem.register_train].
 		</member>
 		<member name="type_name" type="String" setter="set_type_name" getter="get_type_name" default="&quot;&quot;">

--- a/doc_classes/TrainDieselEngine.xml
+++ b/doc_classes/TrainDieselEngine.xml
@@ -25,7 +25,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="Ftmax" type="float" setter="set_traction_force_max" getter="get_traction_force_max" default="0.0">
+		<member name="maximum_traction_force" type="float" setter="set_maximum_traction_force" getter="get_maximum_traction_force" default="0.0">
 			[code]Engine:Ftmax[/code]
 			Maximum traction force, in kN
 		</member>

--- a/doc_classes/TrainDoors.xml
+++ b/doc_classes/TrainDoors.xml
@@ -125,7 +125,7 @@
 			Width (or angle) of full door opening.
 			Note that the original simulator is using the same value for both sides. When both are provided, the simulator will use [code]DoorMaxShiftR[/code] for both sides.
 		</member>
-		<member name="max_shift_plug" type="float" setter="set_max_shift_plug" getter="get_max_shift_plug" default="0.5">
+		<member name="max_shift_plug" type="float" setter="set_max_shift_plug" getter="get_max_shift_plug" default="0.1">
 			[code]Doors:DoorMaxShiftPlug[/code]
 			Bounce distance for Plug-type doors (sliding bounce), in meters
 		</member>
@@ -157,6 +157,10 @@
 			[code]Doors:DoorOpenWithPermit[/code]
 			Opening the train doors by holding down the momentary open permission button for specified number of seconds
 		</member>
+		<member name="permit/default" type="int" setter="set_permit_default" getter="get_permit_default" default="1">
+			[code]Doors:DoorPermitListDefault[/code]
+			By default, the position of the knob is set from the permit/list entry where the positions are numbered starting from 1
+		</member>
 		<member name="permit/light_blinking" type="int" setter="set_permit_light_blinking" getter="get_permit_light_blinking" enum="TrainDoors.PermitLight" default="0">
 			[code]Doors:DoorsPermitLightBlinking[/code]
 			Configuration of the permission light on the door
@@ -170,10 +174,6 @@
 			2 - Permission for right-sided doors
 			3 - Permission for both-sided doors
 			[/codeblocks]
-		</member>
-		<member name="permit/list_default" type="int" setter="set_permit_list_default" getter="get_permit_list_default" default="1">
-			[code]Doors:DoorPermitListDefault[/code]
-			By default, the position of the knob is set from the permit/list entry where the positions are numbered starting from 1
 		</member>
 		<member name="permit/required" type="bool" setter="set_permit_required" getter="get_permit_required" default="false">
 			[code]Doors:DoorNeedPermit[/code]

--- a/doc_classes/TrainElectricEngine.xml
+++ b/doc_classes/TrainElectricEngine.xml
@@ -28,7 +28,8 @@
 		<member name="power/accumulator/recharge_source" type="int" setter="set_accumulator_recharge_source" getter="get_accumulator_recharge_source" enum="TrainController.TrainPowerSource" default="0">
 			Power source for recharging the accumulator
 		</member>
-		<member name="power/current_collector/collector_sliding_width" type="float" setter="set_csw" getter="get_csw" default="0.0">
+		<member name="power/current_collector/collector_sliding_width" type="float" setter="set_collector_sliding_width" getter="get_collector_sliding_width" default="0.0">
+			Sliding width of the power collector (like pantograph)
 		</member>
 		<member name="power/current_collector/max_collector_lifting" type="float" setter="set_max_collector_lifting" getter="get_max_collector_lifting" default="0.0">
 			Maximum collector lifting, in meters.

--- a/doc_classes/TrainLighting.xml
+++ b/doc_classes/TrainLighting.xml
@@ -25,19 +25,21 @@
 		<member name="head_light/color" type="Color" setter="set_head_light_color" getter="get_head_light_color" default="Color(255, 255, 255, 1)">
 			Color of the headlights
 		</member>
-		<member name="head_light/dimming_multiplier" type="float" setter="set_head_light_dimming_multiplier" getter="get_head_light_dimming_multiplier" default="0.6">
+		<member name="head_light/dimmed_multiplier" type="float" setter="set_head_light_dimmed_multiplier" getter="get_head_light_dimmed_multiplier" default="0.6">
 			Multiplier of dimmed headlights intensity
 		</member>
-		<member name="head_light/high_beam/dimming_multiplier" type="float" setter="set_high_beam_dimmed_multiplier" getter="get_high_beam_dimmed_multiplier" default="2.5">
+		<member name="head_light/high_beam/dimmed_multiplier" type="float" setter="set_high_beam_dimmed_multiplier" getter="get_high_beam_dimmed_multiplier" default="2.5">
 			Multiplier of dimmed high beam headlights intensity
 		</member>
-		<member name="head_light/high_beam/normal_multiplier" type="float" setter="set_high_beam_multiplier" getter="get_high_beam_multiplier" default="2.8">
+		<member name="head_light/high_beam/normal_multiplier" type="float" setter="set_high_beam_normal_multiplier" getter="get_high_beam_normal_multiplier" default="2.8">
 			Multiplier of high beam headlights intensity
 		</member>
 		<member name="head_light/normal_multiplier" type="float" setter="set_head_light_normal_multiplier" getter="get_head_light_normal_multiplier" default="1.0">
 			Multiplier of headlights intensity
 		</member>
-		<member name="light/alternative/capacity" type="float" setter="set_alternative_light_capacity" getter="get_alternative_light_capacity" default="24.0">
+		<member name="instrument_type" type="int" setter="set_instrument_type" getter="get_instrument_type" default="0">
+		</member>
+		<member name="light/alternative/capacity" type="float" setter="set_alternative_light_capacity" getter="get_alternative_light_capacity" default="495.0">
 			Specifies the capacity of the alternative light source, typically measured in units like Ampere-hours (Ah). Represents the total amount of energy the alternative light source can store
 		</member>
 		<member name="light/alternative/max_voltage" type="float" setter="set_alternative_max_voltage" getter="get_alternative_max_voltage" default="24.0">
@@ -49,13 +51,13 @@
 		<member name="light/source" type="int" setter="set_light_source" getter="get_light_source" enum="TrainController.TrainPowerSource" default="3">
 			An integer representing the power source, defined by the TrainController.TrainPowerSource enumeration
 		</member>
+		<member name="lights/default_selector_position" type="int" setter="set_lights_default_selector_position" getter="get_lights_default_selector_position" default="0">
+			An integer representing the default position of the light selector
+		</member>
 		<member name="lights/list" type="LightListItem[]" setter="set_light_position_list" getter="get_light_position_list" default="[]">
 			An array of LightListItem objects, each representing a light configuration for one selector position
 		</member>
-		<member name="lights/selector_default_position" type="int" setter="set_lights_selector_default_position" getter="get_lights_selector_default_position" default="0">
-			An integer representing the default position of the light selector
-		</member>
-		<member name="lights/selector_position" type="int" setter="set_light_selector_position" getter="get_light_selector_position" default="0">
+		<member name="lights/selector_position" type="int" setter="set_lights_selector_position" getter="get_lights_selector_position" default="0">
 			An integer representing the current position of the light selector
 		</member>
 		<member name="lights/wrap_selector" type="bool" setter="set_wrap_light_selector" getter="get_wrap_light_selector" default="false">

--- a/doc_classes/TrainSecuritySystem.xml
+++ b/doc_classes/TrainSecuritySystem.xml
@@ -43,15 +43,15 @@
 			[code]Security:MaxHoldTime[/code]
 			The duration of holding down the CA [b]dead man's[/b] button, after which warning lights are turned on.
 		</member>
-		<member name="emergency_brake_delay" type="float" setter="set_emergency_brake_delay" getter="get_emergency_brake_delay" default="0.0">
+		<member name="emergency_brake/delay" type="float" setter="set_emergency_brake_delay" getter="get_emergency_brake_delay" default="0.0">
 			[code]Security:EmergencyBrakeDelay[/code]
 			Time from sound signal activation to emergency brake activation in seconds.
 		</member>
-		<member name="emergency_brake_warning_signal" type="int" setter="set_emergency_brake_warning_signal" getter="get_emergency_brake_warning_signal" enum="TrainSecuritySystem.EmergencyBrakeWarningSignal" default="1">
+		<member name="emergency_brake/warning_signal" type="int" setter="set_emergency_brake_warning_signal" getter="get_emergency_brake_warning_signal" enum="TrainSecuritySystem.EmergencyBrakeWarningSignal" default="1">
 			[code]Security:EmergencyBrakeWarningSignal[/code]
 			Definition of optional, automatic activation of the vehicle siren during emergency braking implementation
 		</member>
-		<member name="radio_stop" type="bool" setter="set_radio_stop" getter="get_radio_stop" default="true">
+		<member name="radio_stop/enabled" type="bool" setter="set_radio_stop_enabled" getter="get_radio_stop_enabled" default="false">
 			[code]Security:RadioStop[/code]
 			Definition of the operation of the Radio-Stop signal.
 		</member>

--- a/src/brakes/TrainBrake.cpp
+++ b/src/brakes/TrainBrake.cpp
@@ -5,166 +5,35 @@
 
 namespace godot {
     void TrainBrake::_bind_methods() {
-
-        ClassDB::bind_method(D_METHOD("set_valve"), &TrainBrake::set_valve);
-        ClassDB::bind_method(D_METHOD("get_valve"), &TrainBrake::get_valve);
-
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "valve/type", PROPERTY_HINT_ENUM,
-                        "NoValve,W,W_Lu_VI,W_Lu_L,W_Lu_XR,K,Kg,Kp,Kss,Kkg,Kkp,Kks,Hikg1,Hikss,Hikp1,KE,SW,"
-                        "EStED,NESt3,ESt3,LSt,ESt4,ESt3AL2,EP1,EP2,M483,CV1_L_TR,CV1,CV1_R,Other"),
-                "set_valve", "get_valve");
-        ClassDB::bind_method(
-                D_METHOD("set_friction_elements_per_axle", "friction_elements_per_axle"),
-                &TrainBrake::set_friction_elements_per_axle);
-        ClassDB::bind_method(D_METHOD("get_friction_elements_per_axle"), &TrainBrake::get_friction_elements_per_axle);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "friction_elements_per_axle"), "set_friction_elements_per_axle",
-                "get_friction_elements_per_axle");
-
-        ClassDB::bind_method(D_METHOD("set_max_brake_force"), &TrainBrake::set_max_brake_force);
-        ClassDB::bind_method(D_METHOD("get_max_brake_force"), &TrainBrake::get_max_brake_force);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "brake_force/max"), "set_max_brake_force", "get_max_brake_force");
-
-        ClassDB::bind_method(D_METHOD("set_valve_size"), &TrainBrake::set_valve_size);
-        ClassDB::bind_method(D_METHOD("get_valve_size"), &TrainBrake::get_valve_size);
-        ADD_PROPERTY(PropertyInfo(Variant::INT, "valve/est_size"), "set_valve_size", "get_valve_size");
-
-        ClassDB::bind_method(D_METHOD("set_track_brake_force"), &TrainBrake::set_track_brake_force);
-        ClassDB::bind_method(D_METHOD("get_track_brake_force"), &TrainBrake::get_track_brake_force);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "brake_force/track"), "set_track_brake_force", "get_track_brake_force");
-        ClassDB::bind_method(D_METHOD("set_max_pressure"), &TrainBrake::set_max_pressure);
-        ClassDB::bind_method(D_METHOD("get_max_pressure"), &TrainBrake::get_max_pressure);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_pressures/cylinder"), "set_max_pressure", "get_max_pressure");
-
-        ClassDB::bind_method(D_METHOD("set_max_pressure_aux"), &TrainBrake::set_max_pressure_aux);
-        ClassDB::bind_method(D_METHOD("get_max_pressure_aux"), &TrainBrake::get_max_pressure_aux);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_pressures/aux"), "set_max_pressure_aux", "get_max_pressure_aux");
-
-        ClassDB::bind_method(D_METHOD("set_max_pressure_tare"), &TrainBrake::set_max_pressure_tare);
-        ClassDB::bind_method(D_METHOD("get_max_pressure_tare"), &TrainBrake::get_max_pressure_tare);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "max_pressures/tare"), "set_max_pressure_tare", "get_max_pressure_tare");
-
-        ClassDB::bind_method(D_METHOD("set_max_pressure_medium"), &TrainBrake::set_max_pressure_medium);
-        ClassDB::bind_method(D_METHOD("get_max_pressure_medium"), &TrainBrake::get_max_pressure_medium);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "max_pressures/medium"), "set_max_pressure_medium",
-                "get_max_pressure_medium");
-
-        ClassDB::bind_method(D_METHOD("set_max_antislip_pressure"), &TrainBrake::set_max_antislip_pressure);
-        ClassDB::bind_method(D_METHOD("get_max_antislip_pressure"), &TrainBrake::get_max_antislip_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "max_pressures/antislip"), "set_max_antislip_pressure",
-                "get_max_antislip_pressure");
-
-        ClassDB::bind_method(D_METHOD("set_cylinders_count"), &TrainBrake::set_cylinders_count);
-        ClassDB::bind_method(D_METHOD("get_cylinders_count"), &TrainBrake::get_cylinders_count);
-        ADD_PROPERTY(PropertyInfo(Variant::INT, "cylinders/count"), "set_cylinders_count", "get_cylinders_count");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_radius"), &TrainBrake::set_cylinder_radius);
-        ClassDB::bind_method(D_METHOD("get_cylinder_radius"), &TrainBrake::get_cylinder_radius);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cylinders/radius"), "set_cylinder_radius", "get_cylinder_radius");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_distance"), &TrainBrake::set_cylinder_distance);
-        ClassDB::bind_method(D_METHOD("get_cylinder_distance"), &TrainBrake::get_cylinder_distance);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "cylinders/distance"), "set_cylinder_distance", "get_cylinder_distance");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_spring_force"), &TrainBrake::set_cylinder_spring_force);
-        ClassDB::bind_method(D_METHOD("get_cylinder_spring_force"), &TrainBrake::get_cylinder_spring_force);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "cylinders/spring_force"), "set_cylinder_spring_force",
-                "get_cylinder_spring_force");
-
-        ClassDB::bind_method(D_METHOD("set_slck_adjustment_force"), &TrainBrake::set_slck_adjustment_force);
-        ClassDB::bind_method(D_METHOD("get_slck_adjustment_force"), &TrainBrake::get_slck_adjustment_force);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "slck/adjustment_force"), "set_slck_adjustment_force",
-                "get_slck_adjustment_force");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_gear_ratio"), &TrainBrake::set_cylinder_gear_ratio);
-        ClassDB::bind_method(D_METHOD("get_cylinder_gear_ratio"), &TrainBrake::get_cylinder_gear_ratio);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "cylinders/gear_ratio"), "set_cylinder_gear_ratio",
-                "get_cylinder_gear_ratio");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_gear_ratio_low"), &TrainBrake::set_cylinder_gear_ratio_low);
-        ClassDB::bind_method(D_METHOD("get_cylinder_gear_ratio_low"), &TrainBrake::get_cylinder_gear_ratio_low);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "cylinders/gear_ratio_low"), "set_cylinder_gear_ratio_low",
-                "get_cylinder_gear_ratio_low");
-
-        ClassDB::bind_method(D_METHOD("set_cylinder_gear_ratio_high"), &TrainBrake::set_cylinder_gear_ratio_high);
-        ClassDB::bind_method(D_METHOD("get_cylinder_gear_ratio_high"), &TrainBrake::get_cylinder_gear_ratio_high);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "cylinders/gear_ratio_high"), "set_cylinder_gear_ratio_high",
-                "get_cylinder_gear_ratio_high");
-
-        ClassDB::bind_method(D_METHOD("set_pipe_pressure_min"), &TrainBrake::set_pipe_pressure_min);
-        ClassDB::bind_method(D_METHOD("get_pipe_pressure_min"), &TrainBrake::get_pipe_pressure_min);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "pipe/pressure_min"), "set_pipe_pressure_min", "get_pipe_pressure_min");
-
-        ClassDB::bind_method(D_METHOD("set_pipe_pressure_max"), &TrainBrake::set_pipe_pressure_max);
-        ClassDB::bind_method(D_METHOD("get_pipe_pressure_max"), &TrainBrake::get_pipe_pressure_max);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "pipe/pressure_max"), "set_pipe_pressure_max", "get_pipe_pressure_max");
-
-        ClassDB::bind_method(D_METHOD("set_main_tank_volume"), &TrainBrake::set_main_tank_volume);
-        ClassDB::bind_method(D_METHOD("get_main_tank_volume"), &TrainBrake::get_main_tank_volume);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tank/volume_main"), "set_main_tank_volume", "get_main_tank_volume");
-
-        ClassDB::bind_method(D_METHOD("set_aux_tank_volume"), &TrainBrake::set_aux_tank_volume);
-        ClassDB::bind_method(D_METHOD("get_aux_tank_volume"), &TrainBrake::get_aux_tank_volume);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tank/volume_aux"), "set_aux_tank_volume", "get_aux_tank_volume");
-
-        ClassDB::bind_method(D_METHOD("set_compressor_pressure_min"), &TrainBrake::set_compressor_pressure_min);
-        ClassDB::bind_method(D_METHOD("get_compressor_pressure_min"), &TrainBrake::get_compressor_pressure_min);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "compressor/pressure_min"), "set_compressor_pressure_min",
-                "get_compressor_pressure_min");
-
-        ClassDB::bind_method(D_METHOD("set_compressor_pressure_max"), &TrainBrake::set_compressor_pressure_max);
-        ClassDB::bind_method(D_METHOD("get_compressor_pressure_max"), &TrainBrake::get_compressor_pressure_max);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "compressor/pressure_max"), "set_compressor_pressure_max",
-                "get_compressor_pressure_max");
-
-        ClassDB::bind_method(
-                D_METHOD("set_compressor_pressure_cab_b_min"), &TrainBrake::set_compressor_pressure_cab_b_min);
-        ClassDB::bind_method(
-                D_METHOD("get_compressor_pressure_cab_b_min"), &TrainBrake::get_compressor_pressure_cab_b_min);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "compressor/pressure_cab_b_min"), "set_compressor_pressure_cab_b_min",
-                "get_compressor_pressure_cab_b_min");
-
-        ClassDB::bind_method(
-                D_METHOD("set_compressor_pressure_cab_b_max"), &TrainBrake::set_compressor_pressure_cab_b_max);
-        ClassDB::bind_method(
-                D_METHOD("get_compressor_pressure_cab_b_max"), &TrainBrake::get_compressor_pressure_cab_b_max);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "compressor/pressure_cab_b_max"), "set_compressor_pressure_cab_b_max",
-                "get_compressor_pressure_cab_b_max");
-
-        ClassDB::bind_method(D_METHOD("set_compressor_speed"), &TrainBrake::set_compressor_speed);
-        ClassDB::bind_method(D_METHOD("get_compressor_speed"), &TrainBrake::get_compressor_speed);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "compressor/speed"), "set_compressor_speed", "get_compressor_speed");
-
-        ClassDB::bind_method(D_METHOD("set_compressor_power"), &TrainBrake::set_compressor_power);
-        ClassDB::bind_method(D_METHOD("get_compressor_power"), &TrainBrake::get_compressor_power);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "compressor/power", PROPERTY_HINT_ENUM,
-                        "Main,UNUSED,Converter,Engine,Coupler1,Coupler2"),
-                "set_compressor_power", "get_compressor_power");
-
-        ClassDB::bind_method(D_METHOD("set_rig_effectiveness"), &TrainBrake::set_rig_effectiveness);
-        ClassDB::bind_method(D_METHOD("get_rig_effectiveness"), &TrainBrake::get_rig_effectiveness);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "rig_effectiveness"), "set_rig_effectiveness", "get_rig_effectiveness");
+        BIND_PROPERTY_W_HINT(Variant::INT, "valve_type", "valve/type", &TrainBrake::set_valve_type, &TrainBrake::get_valve_type, "valve_type", PROPERTY_HINT_ENUM, "NoValve,W,W_Lu_VI,W_Lu_L,W_Lu_XR,K,Kg,Kp,Kss,Kkg,Kkp,Kks,Hikg1,Hikss,Hikp1,KE,SW,EStED,NESt3,ESt3,LSt,ESt4,ESt3AL2,EP1,EP2,M483,CV1_L_TR,CV1,CV1_R,Other")
+        BIND_PROPERTY(Variant::INT, "friction_elements_per_axle", "friction_elements_per_axle", &TrainBrake::set_friction_elements_per_axle, &TrainBrake::get_friction_elements_per_axle, "friction_elements_per_axle");
+        BIND_PROPERTY(Variant::FLOAT, "max_brake_force", "brake_force/max", &TrainBrake::set_max_brake_force, &TrainBrake::get_max_brake_force, "max_brake_force");
+        BIND_PROPERTY(Variant::INT, "est_valve_size", "est_valve/size", &TrainBrake::set_valve_size, &TrainBrake::get_valve_size, "valve_size");
+        BIND_PROPERTY(Variant::FLOAT, "traction_brake_force", "brake_force/traction", &TrainBrake::set_traction_brake_force, &TrainBrake::get_traction_brake_force, "traction_brake_force");
+        BIND_PROPERTY(Variant::FLOAT, "max_cylinder_pressure", "max_cylinder_pressure", &TrainBrake::set_max_cyl_pressure, &TrainBrake::get_max_cyl_pressure, "max_cylinder_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "max_aux_pressure", "max_aux_pressure", &TrainBrake::set_max_aux_pressure, &TrainBrake::get_max_aux_pressure, "max_aux_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "max_tare_pressure", "max_tare_pressure", &TrainBrake::set_max_tare_pressure, &TrainBrake::get_max_tare_pressure, "max_tare_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "max_medium_pressure", "max_medium_pressure", &TrainBrake::set_max_medium_pressure, &TrainBrake::get_max_medium_pressure, "max_medium_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "max_antislip_pressure", "max_antislip_pressure", &TrainBrake::set_max_antislip_pressure, &TrainBrake::get_max_antislip_pressure, "max_antislip_pressure");
+        BIND_PROPERTY(Variant::INT, "cylinder_count", "cylinder/count", &TrainBrake::set_cyl_count, &TrainBrake::get_cyl_count, "cylinder_count");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_radius", "cylinder/radius", &TrainBrake::set_cyl_radius, &TrainBrake::get_cyl_radius, "cylinder_radius");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_distance", "cylinder/distance", &TrainBrake::set_cyl_distance, &TrainBrake::get_cyl_distance, "cylinder_distance");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_spring_force", "cylinder/spring_force", &TrainBrake::set_cyl_spring_force, &TrainBrake::get_cyl_spring_force, "cylinder_spring_force");
+        BIND_PROPERTY(Variant::FLOAT, "piston_stroke_adjuster_resistance", "piston_stroke/adjuster_resistance", &TrainBrake::set_piston_stroke_adjuster_resistance, &TrainBrake::get_piston_stroke_adjuster_resistance, "");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_gear_ratio", "cylinder/gear_ratio", &TrainBrake::set_cyl_gear_ratio, &TrainBrake::get_cyl_gear_ratio, "cylinder_gear_ratio");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_gear_ratio_low", "cylinder/gear_ratio_low", &TrainBrake::set_cyl_gear_ratio_low, &TrainBrake::get_cyl_gear_ratio_low, "cylinder_gear_ratio_low");
+        BIND_PROPERTY(Variant::FLOAT, "cylinder_gear_ratio_high", "cylinder/gear_ratio_high", &TrainBrake::set_cyl_gear_ratio_high, &TrainBrake::get_cyl_gear_ratio_high, "cylinder_gear_ratio_high");
+        BIND_PROPERTY(Variant::FLOAT, "pipe_pressure_min", "pipe/pressure_min", &TrainBrake::set_pipe_pressure_min, &TrainBrake::get_pipe_pressure_min, "pipe_pressure_min");
+        BIND_PROPERTY(Variant::FLOAT, "pipe_pressure_max", "pipe/pressure_max", &TrainBrake::set_pipe_pressure_max, &TrainBrake::get_pipe_pressure_max, "pipe_pressure_max");
+        BIND_PROPERTY(Variant::FLOAT, "main_tank_volume", "tank/volume_main", &TrainBrake::set_main_tank_volume, &TrainBrake::get_main_tank_volume, "main_tank_volume");
+        BIND_PROPERTY(Variant::FLOAT, "aux_tank_volume", "tank/volume_aux", &TrainBrake::set_aux_tank_volume, &TrainBrake::get_aux_tank_volume, "aux_tank_volume");
+        BIND_PROPERTY(Variant::FLOAT, "compressor_pressure_cab_a_min", "compressor/cab_a/min_pressure", &TrainBrake::set_compressor_pressure_cab_a_min, &TrainBrake::get_compressor_pressure_cab_a_min, "compressor_pressure_min");
+        BIND_PROPERTY(Variant::FLOAT, "compressor_pressure_cab_a_max", "compressor/cab_a/max_pressure", &TrainBrake::set_compressor_pressure_cab_a_max, &TrainBrake::get_compressor_pressure_cab_a_max, "compressor_pressure_max");
+        BIND_PROPERTY(Variant::FLOAT, "compressor_pressure_cab_b_min", "compressor/cab_b/min_pressure", &TrainBrake::set_compressor_pressure_cab_b_min, &TrainBrake::get_compressor_pressure_cab_b_min, "compressor_pressure_min");
+        BIND_PROPERTY(Variant::FLOAT, "compressor_pressure_cab_b_max", "compressor/cab_b/max_pressure", &TrainBrake::set_compressor_pressure_cab_b_max, &TrainBrake::get_compressor_pressure_cab_b_max, "compressor_pressure_max");
+        BIND_PROPERTY(Variant::FLOAT, "compressor_speed", "compressor/speed", &TrainBrake::set_compressor_speed, &TrainBrake::get_compressor_speed, "compressor_speed");
+        BIND_PROPERTY_W_HINT(Variant::INT, "compressor_power", "compressor/power", &TrainBrake::set_compressor_power, &TrainBrake::get_compressor_power, "compressor_power", PROPERTY_HINT_ENUM, "Main,Unused,Converter,Engine,Coupler1,Coupler2");
+        BIND_PROPERTY(Variant::FLOAT, "rig_effectiveness", "rig_effectiveness", &TrainBrake::set_rig_effectiveness, &TrainBrake::get_rig_effectiveness, "rig_effectiveness");
 
         BIND_ENUM_CONSTANT(COMPRESSOR_POWER_MAIN);
         BIND_ENUM_CONSTANT(COMPRESSOR_POWER_UNUSED);
@@ -335,40 +204,41 @@ namespace godot {
          */
 
         // assuming same int values between our TrainBrakeValve and mover's TBrakeValve
-        mover->BrakeValve = static_cast<TBrakeValve>(static_cast<int>(valve));
+        mover->BrakeValve = static_cast<TBrakeValve>(static_cast<int>(valve_type));
 
-        const auto it = BrakeValveToSubsystemMap.find(mover->BrakeValve);
+        const std::unordered_map<TBrakeValve, TBrakeSubSystem>::const_iterator it =
+                BrakeValveToSubsystemMap.find(mover->BrakeValve);
         mover->BrakeSubsystem = it != BrakeValveToSubsystemMap.end() ? it->second : TBrakeSubSystem::ss_None;
 
         mover->NBpA = friction_elements_per_axle;
         mover->MaxBrakeForce = max_brake_force;
         mover->BrakeValveSize = valve_size;
-        mover->TrackBrakeForce = track_brake_force * 1000.0;
-        mover->MaxBrakePress[3] = max_pressure;
-        if (max_pressure > 0.0) {
-            mover->BrakeCylNo = cylinders_count;
+        mover->TrackBrakeForce = traction_brake_force * 1000.0;
+        mover->MaxBrakePress[3] = max_cyl_pressure;
+        if (max_cyl_pressure > 0.0) {
+            mover->BrakeCylNo = cyl_count;
 
-            if (cylinders_count > 0) {
-                mover->MaxBrakePress[0] = max_pressure_aux < 0.01 ? max_pressure : max_pressure_aux;
-                mover->MaxBrakePress[1] = max_pressure_tare;
-                mover->MaxBrakePress[2] = max_pressure_medium;
+            if (cyl_count > 0) {
+                mover->MaxBrakePress[0] = max_aux_pressure < 0.01 ? max_cyl_pressure : max_aux_pressure;
+                mover->MaxBrakePress[1] = max_tare_pressure;
+                mover->MaxBrakePress[2] = max_medium_pressure;
                 mover->MaxBrakePress[4] = max_antislip_pressure < 0.01 ? 0.0 : max_antislip_pressure;
 
-                mover->BrakeCylRadius = cylinder_radius;
-                mover->BrakeCylDist = cylinder_distance;
-                mover->BrakeCylSpring = cylinder_spring_force;
-                mover->BrakeSlckAdj = slck_adjustment_force;
+                mover->BrakeCylRadius = cyl_radius;
+                mover->BrakeCylDist = cyl_distance;
+                mover->BrakeCylSpring = cyl_spring_force;
+                mover->BrakeSlckAdj = piston_stroke_adjuster_resistance;
                 mover->BrakeRigEff = rig_effectiveness;
 
-                mover->BrakeCylMult[0] = cylinder_gear_ratio;
-                mover->BrakeCylMult[1] = cylinder_gear_ratio_low;
-                mover->BrakeCylMult[2] = cylinder_gear_ratio_high;
+                mover->BrakeCylMult[0] = cyl_gear_ratio;
+                mover->BrakeCylMult[1] = cyl_gear_ratio_low;
+                mover->BrakeCylMult[2] = cyl_gear_ratio_high;
 
-                mover->P2FTrans = 100 * M_PI * std::pow(cylinder_radius, 2);
+                mover->P2FTrans = 100 * M_PI * std::pow(cyl_radius, 2);
 
-                mover->LoadFlag = (cylinder_gear_ratio_low > 0.0 || max_pressure_tare > 0.0) ? 1 : 0;
+                mover->LoadFlag = (cyl_gear_ratio_low > 0.0 || max_tare_pressure > 0.0) ? 1 : 0;
 
-                mover->BrakeVolume = M_PI * std::pow(cylinder_radius, 2) * cylinder_distance * cylinders_count;
+                mover->BrakeVolume = M_PI * std::pow(cyl_radius, 2) * cyl_distance * cyl_count;
                 mover->BrakeVVolume = aux_tank_volume;
 
                 // TODO: mover->BrakeMethod
@@ -384,270 +254,11 @@ namespace godot {
         mover->HighPipePress = pipe_pressure_max;
         mover->LowPipePress = pipe_pressure_min;
         mover->VeselVolume = main_tank_volume;
-        mover->MinCompressor = compressor_pressure_min;
-        mover->MaxCompressor = compressor_pressure_max;
+        mover->MinCompressor = compressor_pressure_cab_a_min;
+        mover->MaxCompressor = compressor_pressure_cab_a_max;
         mover->MinCompressor_cabB = compressor_pressure_cab_b_min;
         mover->MaxCompressor_cabB = compressor_pressure_cab_b_max;
         mover->CompressorSpeed = compressor_speed;
         mover->CompressorPower = compressor_power;
-    }
-
-    void TrainBrake::set_valve(const TrainBrakeValve p_valve) {
-        valve = p_valve;
-        _dirty = true;
-    }
-
-    TrainBrake::TrainBrakeValve TrainBrake::get_valve() const {
-        return valve;
-    }
-
-    void TrainBrake::set_friction_elements_per_axle(const int p_friction_elements_per_axle) {
-        friction_elements_per_axle = p_friction_elements_per_axle;
-        _dirty = true;
-    }
-
-    int TrainBrake::get_friction_elements_per_axle() const {
-        return friction_elements_per_axle;
-    }
-
-    void TrainBrake::set_max_brake_force(const double p_max_brake_force) {
-        max_brake_force = p_max_brake_force;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_brake_force() const {
-        return max_brake_force;
-    }
-
-    void TrainBrake::set_valve_size(const int p_valve_size) {
-        valve_size = p_valve_size;
-        _dirty = true;
-    }
-
-    int TrainBrake::get_valve_size() const {
-        return valve_size;
-    }
-
-    void TrainBrake::set_track_brake_force(const double p_track_brake_force) {
-        track_brake_force = p_track_brake_force;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_track_brake_force() const {
-        return track_brake_force;
-    }
-
-    void TrainBrake::set_max_pressure(const double p_max_pressure) {
-        max_pressure = p_max_pressure;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_pressure() const {
-        return max_pressure;
-    }
-
-    void TrainBrake::set_max_pressure_aux(const double p_value) {
-        max_pressure_aux = p_value;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_pressure_aux() const {
-        return max_pressure_aux;
-    }
-
-    void TrainBrake::set_max_pressure_tare(const double p_value) {
-        max_pressure_tare = p_value;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_pressure_tare() const {
-        return max_pressure_tare;
-    }
-
-    void TrainBrake::set_max_pressure_medium(const double p_value) {
-        max_pressure_medium = p_value;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_pressure_medium() const {
-        return max_pressure_medium;
-    }
-
-    void TrainBrake::set_max_antislip_pressure(const double p_max_antislip_pressure) {
-        max_antislip_pressure = p_max_antislip_pressure;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_max_antislip_pressure() const {
-        return max_antislip_pressure;
-    }
-
-    void TrainBrake::set_cylinders_count(const int p_cylinders_count) {
-        cylinders_count = p_cylinders_count;
-        _dirty = true;
-    }
-
-    int TrainBrake::get_cylinders_count() const {
-        return cylinders_count;
-    }
-
-    void TrainBrake::set_cylinder_radius(const double p_cylinder_radius) {
-        cylinder_radius = p_cylinder_radius;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_cylinder_radius() const {
-        return cylinder_radius;
-    }
-
-    void TrainBrake::set_cylinder_distance(const double p_cylinder_distance) {
-        cylinder_distance = p_cylinder_distance;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_cylinder_distance() const {
-        return cylinder_distance;
-    }
-
-    void TrainBrake::set_cylinder_spring_force(const double p_cylinder_spring_force) {
-        cylinder_spring_force = p_cylinder_spring_force;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_cylinder_spring_force() const {
-        return cylinder_spring_force;
-    }
-
-    void TrainBrake::set_slck_adjustment_force(const double p_slck_adjustment_force) {
-        slck_adjustment_force = p_slck_adjustment_force;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_slck_adjustment_force() const {
-        return slck_adjustment_force;
-    }
-
-    void TrainBrake::set_cylinder_gear_ratio(const double p_cylinder_gear_ratio) {
-        cylinder_gear_ratio = p_cylinder_gear_ratio;
-    }
-
-    double TrainBrake::get_cylinder_gear_ratio() const {
-        return cylinder_gear_ratio;
-    }
-
-    void TrainBrake::set_cylinder_gear_ratio_low(const double p_cylinder_gear_ratio_low) {
-        cylinder_gear_ratio_low = p_cylinder_gear_ratio_low;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_cylinder_gear_ratio_low() const {
-        return cylinder_gear_ratio_low;
-    }
-
-    void TrainBrake::set_cylinder_gear_ratio_high(const double p_cylinder_gear_ratio_high) {
-        cylinder_gear_ratio_high = p_cylinder_gear_ratio_high;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_cylinder_gear_ratio_high() const {
-        return cylinder_gear_ratio_high;
-    }
-
-    void TrainBrake::set_pipe_pressure_max(const double p_pipe_pressure_max) {
-        pipe_pressure_max = p_pipe_pressure_max;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_pipe_pressure_max() const {
-        return pipe_pressure_max;
-    }
-
-    void TrainBrake::set_pipe_pressure_min(const double p_pipe_pressure_min) {
-        pipe_pressure_min = std::max(3.5, p_pipe_pressure_min); // MOVER LoadFiz_Brake
-        _dirty = true;
-    }
-
-    double TrainBrake::get_pipe_pressure_min() const {
-        return pipe_pressure_min;
-    }
-    void TrainBrake::set_main_tank_volume(const double p_main_tank_volume) {
-        main_tank_volume = p_main_tank_volume;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_main_tank_volume() const {
-        return main_tank_volume;
-    }
-
-    void TrainBrake::set_aux_tank_volume(const double p_aux_tank_volume) {
-        aux_tank_volume = p_aux_tank_volume;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_aux_tank_volume() const {
-        return aux_tank_volume;
-    }
-
-    void TrainBrake::set_compressor_pressure_min(const double p_compressor_pressure_min) {
-        compressor_pressure_min = p_compressor_pressure_min;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_compressor_pressure_min() const {
-        return compressor_pressure_min;
-    }
-
-    void TrainBrake::set_compressor_pressure_max(const double p_compressor_pressure_max) {
-        compressor_pressure_max = p_compressor_pressure_max;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_compressor_pressure_max() const {
-        return compressor_pressure_max;
-    }
-
-    void TrainBrake::set_compressor_pressure_cab_b_min(const double p_compressor_pressure_cab_b_min) {
-        compressor_pressure_cab_b_min = p_compressor_pressure_cab_b_min;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_compressor_pressure_cab_b_min() const {
-        return compressor_pressure_cab_b_min;
-    }
-
-    void TrainBrake::set_compressor_pressure_cab_b_max(const double p_compressor_pressure_cab_b_max) {
-        compressor_pressure_cab_b_max = p_compressor_pressure_cab_b_max;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_compressor_pressure_cab_b_max() const {
-        return compressor_pressure_cab_b_max;
-    }
-
-    void TrainBrake::set_compressor_speed(const double p_compressor_speed) {
-        compressor_speed = p_compressor_speed;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_compressor_speed() const {
-        return compressor_speed;
-    }
-
-    void TrainBrake::set_compressor_power(const CompressorPower p_compressor_power) {
-        compressor_power = p_compressor_power;
-        _dirty = true;
-    }
-
-    TrainBrake::CompressorPower TrainBrake::get_compressor_power() const {
-        return compressor_power;
-    }
-
-    void TrainBrake::set_rig_effectiveness(const double p_rig_effectiveness) {
-        rig_effectiveness = p_rig_effectiveness;
-        _dirty = true;
-    }
-
-    double TrainBrake::get_rig_effectiveness() const {
-        return rig_effectiveness;
     }
 } // namespace godot

--- a/src/brakes/TrainBrake.hpp
+++ b/src/brakes/TrainBrake.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "macros.hpp"
 #include "../core/TrainPart.hpp"
 #include <godot_cpp/classes/node.hpp>
 #include <unordered_map>
@@ -72,7 +73,7 @@ namespace godot {
                     {BrakeHandlePosition::BRAKE_HANDLE_POSITION_EMERGENCY, Maszyna::bh_EB},
             };
             const std::unordered_map<std::string, int> BrakeHandlePositionStringMap = {
-                    {"min", Maszyna::bh_MIN}, {"max", Maszyna::bh_MAX},      {"drive", Maszyna::bh_RP},
+                    {"min", Maszyna::bh_MIN}, {"max", Maszyna::bh_MAX}, {"drive", Maszyna::bh_RP},
                     {"full", Maszyna::bh_FB}, {"emergency", Maszyna::bh_EB},
             };
             const std::unordered_map<TBrakeValve, TBrakeSubSystem> BrakeValveToSubsystemMap = {
@@ -84,38 +85,35 @@ namespace godot {
                     {TBrakeValve::CV1, TBrakeSubSystem::ss_Dako},  {TBrakeValve::CV1_L_TR, TBrakeSubSystem::ss_Dako},
                     {TBrakeValve::LSt, TBrakeSubSystem::ss_LSt},   {TBrakeValve::EStED, TBrakeSubSystem::ss_LSt}};
 
-            // BrakeValve -> BrakeValve
-            // assuming same int values between our TrainBrakeValve and mover's TBrakeValve
-            TrainBrakeValve valve = static_cast<TrainBrakeValve>(static_cast<int>(TBrakeValve::NoValve));
-
-            int friction_elements_per_axle = 1;                       // NBpA -> NBpA
-            double max_brake_force = 1;                               // MBF -> MaxBrakeForce
-            int valve_size = 0;                                       // Size -> BrakeValveSize
-            double track_brake_force = 0.0;                           // TBF -> TrackBrakeForce
-            double max_pressure = 0.0;                                // MaxBP -> MaxBrakePress[3]
-            double max_pressure_aux = 0.0;                            // MaxLBP -> MaxBrakePress[0]
-            double max_antislip_pressure = 0.0;                       // MaxASBP -> MaxBrakePress[4]
-            double max_pressure_tare = 0.0;                           // TareMaxBP -> MaxBrakePress[1]
-            double max_pressure_medium = 0.0;                         // MedMaxBP -> MaxBrakePress[2]
-            int cylinders_count = 0;                                  // BCN -> BrakeCylNo
-            double cylinder_radius = 0.0;                             // BCR -> BrakeCylRadius
-            double cylinder_distance = 0.0;                           // BCD -> BrakeCylDist
-            double cylinder_spring_force = 0.0;                       // BCS -> BrakeCylSpring
-            double slck_adjustment_force = 0.0;                       // BSA -> BrakeSlckAdj
-            double cylinder_gear_ratio = 0.0;                         // BCM -> BrakeCylMult[0]
-            double cylinder_gear_ratio_low = 0.0;                     // BCMlo -> BrakeCylMult[1]
-            double cylinder_gear_ratio_high = 0.0;                    // BCMHi -> BrakeCylMult[2]
-            double pipe_pressure_max = 5.0;                           // HiPP -> HighPipePress
-            double pipe_pressure_min = 3.5;                           // LoPP -> LowPipePress
-            double main_tank_volume = 0.0;                            // Vv -> VeselVolume
-            double aux_tank_volume = 0.0;                             // BVV -> BrakeVVolume
-            double compressor_pressure_min = 0.0;                     // MinCP -> MinCompressor
-            double compressor_pressure_max = 0.0;                     // MaxCP -> MaxCompressor
-            double compressor_pressure_cab_b_min = 0.0;               // MinCP_B -> MinCompressor_cabB
-            double compressor_pressure_cab_b_max = 0.0;               // MaxCP_B -> MaxCompressor_cabB
-            double compressor_speed = 0.0;                            // CompressorSpeed -> CompressorSpeed
-            CompressorPower compressor_power = COMPRESSOR_POWER_MAIN; // CompressorPower
-            double rig_effectiveness = 0.0;                           // BRE -> BrakeRigEff effectiveness
+            MAKE_MEMBER_GS_NR(TrainBrakeValve, valve_type, static_cast<TrainBrakeValve>(static_cast<int>(TBrakeValve::NoValve)));
+            MAKE_MEMBER_GS(int, valve_size, 0);
+            MAKE_MEMBER_GS(int, friction_elements_per_axle, 1);
+            MAKE_MEMBER_GS(double, max_brake_force, 1.0);
+            MAKE_MEMBER_GS(double, traction_brake_force, 0.0);
+            MAKE_MEMBER_GS(double, max_cyl_pressure, 0.0);
+            MAKE_MEMBER_GS(double, max_aux_pressure, 0.0);
+            MAKE_MEMBER_GS(double, max_antislip_pressure, 0.0);
+            MAKE_MEMBER_GS(double, max_tare_pressure, 0.0);
+            MAKE_MEMBER_GS(double, max_medium_pressure, 0.0);
+            MAKE_MEMBER_GS(int, cyl_count, 0);
+            MAKE_MEMBER_GS(double, cyl_radius, 0.0);
+            MAKE_MEMBER_GS(double, cyl_distance, 0.0);
+            MAKE_MEMBER_GS(double, cyl_spring_force, 0.0);
+            MAKE_MEMBER_GS(double, piston_stroke_adjuster_resistance, 0.0);
+            MAKE_MEMBER_GS(double, cyl_gear_ratio, 0.0);
+            MAKE_MEMBER_GS(double, cyl_gear_ratio_low, 0.0);
+            MAKE_MEMBER_GS(double, cyl_gear_ratio_high, 0.0);
+            MAKE_MEMBER_GS(double, pipe_pressure_max, 5.0);
+            MAKE_MEMBER_GS(double, pipe_pressure_min, 3.5);
+            MAKE_MEMBER_GS(double, main_tank_volume, 0.0);
+            MAKE_MEMBER_GS(double, aux_tank_volume, 0.0);
+            MAKE_MEMBER_GS(double, compressor_pressure_cab_a_min, 0.0);
+            MAKE_MEMBER_GS(double, compressor_pressure_cab_a_max, 0.0);
+            MAKE_MEMBER_GS(double, compressor_pressure_cab_b_min, 0.0);
+            MAKE_MEMBER_GS(double, compressor_pressure_cab_b_max, 0.0);
+            MAKE_MEMBER_GS(double, compressor_speed, 0.0);
+            MAKE_MEMBER_GS_NR(CompressorPower, compressor_power, COMPRESSOR_POWER_MAIN);
+            MAKE_MEMBER_GS(double, rig_effectiveness, 0.0);
 
         protected:
             void _do_update_internal_mover(TMoverParameters *mover) override;
@@ -126,94 +124,6 @@ namespace godot {
 
         public:
             static void _bind_methods();
-
-            void set_valve(TrainBrakeValve p_valve);
-            TrainBrakeValve get_valve() const;
-
-            void set_friction_elements_per_axle(int p_friction_elements_per_axle);
-            int get_friction_elements_per_axle() const;
-
-            void set_max_brake_force(double p_max_brake_force);
-            double get_max_brake_force() const;
-
-            void set_valve_size(int p_valve_size);
-            int get_valve_size() const;
-
-            void set_track_brake_force(double p_track_brake_force);
-            double get_track_brake_force() const;
-
-            void set_max_pressure(double p_max_pressure);
-            double get_max_pressure() const;
-
-            void set_max_pressure_aux(double p_value);
-            double get_max_pressure_aux() const;
-
-            void set_max_pressure_tare(double p_value);
-            double get_max_pressure_tare() const;
-
-            void set_max_pressure_medium(double p_value);
-            double get_max_pressure_medium() const;
-
-            void set_max_antislip_pressure(double p_max_antislip_pressure);
-            double get_max_antislip_pressure() const;
-
-            void set_cylinders_count(int p_cylinders_count);
-            int get_cylinders_count() const;
-
-            void set_cylinder_radius(double p_cylinder_radius);
-            double get_cylinder_radius() const;
-
-            void set_cylinder_distance(double p_cylinder_distance);
-            double get_cylinder_distance() const;
-
-            void set_cylinder_spring_force(double p_cylinder_spring_force);
-            double get_cylinder_spring_force() const;
-
-            void set_slck_adjustment_force(double p_slck_adjustment_force);
-            double get_slck_adjustment_force() const;
-
-            void set_cylinder_gear_ratio(double p_cylinder_gear_ratio);
-            double get_cylinder_gear_ratio() const;
-
-            void set_cylinder_gear_ratio_low(double p_cylinder_gear_ratio_low);
-            double get_cylinder_gear_ratio_low() const;
-
-            void set_cylinder_gear_ratio_high(double p_cylinder_gear_ratio_high);
-            double get_cylinder_gear_ratio_high() const;
-
-            void set_pipe_pressure_max(double p_pipe_pressure_max);
-            double get_pipe_pressure_max() const;
-
-            void set_pipe_pressure_min(double p_pipe_pressure_min);
-            double get_pipe_pressure_min() const;
-
-            void set_main_tank_volume(double p_main_tank_volume);
-            double get_main_tank_volume() const;
-
-            void set_aux_tank_volume(double p_aux_tank_volume);
-            double get_aux_tank_volume() const;
-
-            void set_compressor_pressure_min(double p_compressor_pressure_min);
-            double get_compressor_pressure_min() const;
-
-            void set_compressor_pressure_max(double p_compressor_pressure_max);
-            double get_compressor_pressure_max() const;
-
-            void set_compressor_pressure_cab_b_min(double p_compressor_pressure_cab_b_min);
-            double get_compressor_pressure_cab_b_min() const;
-
-            void set_compressor_pressure_cab_b_max(double p_compressor_pressure_cab_b_max);
-            double get_compressor_pressure_cab_b_max() const;
-
-            void set_compressor_speed(double p_compressor_speed);
-            double get_compressor_speed() const;
-
-            void set_compressor_power(CompressorPower p_compressor_power);
-            CompressorPower get_compressor_power() const;
-
-            void set_rig_effectiveness(double p_rig_effectiveness);
-            double get_rig_effectiveness() const;
-
             void brake_releaser(bool p_pressed);
             void brake_level_set(double p_level);
             void brake_level_set_position(BrakeHandlePosition p_position);

--- a/src/core/TrainController.cpp
+++ b/src/core/TrainController.cpp
@@ -59,33 +59,16 @@ namespace godot {
         ClassDB::bind_method(D_METHOD("update_state"), &TrainController::update_state);
         ClassDB::bind_method(D_METHOD("update_config"), &TrainController::update_config);
 
-        ClassDB::bind_method(D_METHOD("set_train_id"), &TrainController::set_train_id);
-        ClassDB::bind_method(D_METHOD("get_train_id"), &TrainController::get_train_id);
-        ClassDB::bind_method(D_METHOD("set_type_name"), &TrainController::set_type_name);
-        ClassDB::bind_method(D_METHOD("get_type_name"), &TrainController::get_type_name);
-        ClassDB::bind_method(D_METHOD("set_mass"), &TrainController::set_mass);
-        ClassDB::bind_method(D_METHOD("get_mass"), &TrainController::get_mass);
-        ClassDB::bind_method(D_METHOD("set_power"), &TrainController::set_power);
-        ClassDB::bind_method(D_METHOD("get_power"), &TrainController::get_power);
-        ClassDB::bind_method(D_METHOD("set_max_velocity"), &TrainController::set_max_velocity);
-        ClassDB::bind_method(D_METHOD("get_max_velocity"), &TrainController::get_max_velocity);
-        ClassDB::bind_method(D_METHOD("set_axle_arrangement"), &TrainController::set_axle_arrangement);
-        ClassDB::bind_method(D_METHOD("get_axle_arrangement"), &TrainController::get_axle_arrangement);
-        ClassDB::bind_method(D_METHOD("set_battery_voltage"), &TrainController::set_battery_voltage);
-        ClassDB::bind_method(D_METHOD("get_battery_voltage"), &TrainController::get_battery_voltage);
-        ClassDB::bind_method(D_METHOD("set_radio_channel_min"), &TrainController::set_radio_channel_min);
-        ClassDB::bind_method(D_METHOD("get_radio_channel_min"), &TrainController::get_radio_channel_min);
-        ClassDB::bind_method(D_METHOD("set_radio_channel_max"), &TrainController::set_radio_channel_min);
-        ClassDB::bind_method(D_METHOD("get_radio_channel_max"), &TrainController::get_radio_channel_min);
-
-        ADD_PROPERTY(PropertyInfo(Variant::STRING, "train_id"), "set_train_id", "get_train_id");
-        ADD_PROPERTY(PropertyInfo(Variant::STRING, "type_name"), "set_type_name", "get_type_name");
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dimensions/mass"), "set_mass", "get_mass");
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "power"), "set_power", "get_power");
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_velocity"), "set_max_velocity", "get_max_velocity");
-        ADD_PROPERTY(PropertyInfo(Variant::STRING, "axle_arrangement"), "set_axle_arrangement", "get_axle_arrangement");
-        ADD_PROPERTY(PropertyInfo(Variant::INT, "radio/channel_min"), "set_radio_channel_min", "get_radio_channel_min");
-        ADD_PROPERTY(PropertyInfo(Variant::INT, "radio/channel_max"), "set_radio_channel_max", "get_radio_channel_max");
+        BIND_PROPERTY(Variant::STRING, "train_id", "train_id", &TrainController::set_train_id, &TrainController::get_train_id, "train_id");
+        BIND_PROPERTY(Variant::STRING, "type_name", "type_name", &TrainController::set_type_name, &TrainController::get_type_name, "type_name");
+        BIND_PROPERTY(Variant::FLOAT, "mass", "mass", &TrainController::set_mass, &TrainController::get_mass, "mass");
+        BIND_PROPERTY(Variant::FLOAT, "power", "power", &TrainController::set_power, &TrainController::get_power, "power");
+        BIND_PROPERTY(Variant::FLOAT, "max_velocity", "max_velocity", &TrainController::set_max_velocity, &TrainController::get_max_velocity, "max_velocity");
+        BIND_PROPERTY(Variant::STRING, "axle_arrangement", "axle_arrangement", &TrainController::set_axle_arrangement, &TrainController::get_axle_arrangement, "axle_arrangement");
+        BIND_PROPERTY(Variant::INT, "radio_channel_min", "radio_channel/min", &TrainController::set_radio_channel_min, &TrainController::get_radio_channel_min, "radio_channel_min");
+        BIND_PROPERTY(Variant::INT, "radio_channel_max", "radio_channel/max", &TrainController::set_radio_channel_max, &TrainController::get_radio_channel_max, "radio_channel_max");
+        /* FIXME: move to TrainPower section? */
+        BIND_PROPERTY_W_HINT(Variant::FLOAT, "battery_voltage", "battery_voltage", &TrainController::set_battery_voltage, &TrainController::get_battery_voltage, "battery_voltage", PROPERTY_HINT_RANGE, "0,500,1");
 
         ADD_SIGNAL(MethodInfo(MOVER_CONFIG_CHANGED_SIGNAL));
         ADD_SIGNAL(MethodInfo(MOVER_INITIALIZED_SIGNAL));
@@ -96,12 +79,6 @@ namespace godot {
         ADD_SIGNAL(MethodInfo(
                 COMMAND_RECEIVED, PropertyInfo(Variant::STRING, "command"), PropertyInfo(Variant::NIL, "p1"),
                 PropertyInfo(Variant::NIL, "p2")));
-
-        /* FIXME: move to TrainPower section? */
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "battery_voltage", PROPERTY_HINT_RANGE, "0,500,1"), "set_battery_voltage",
-                "get_battery_voltage");
-
 
         BIND_ENUM_CONSTANT(POWER_SOURCE_NOT_DEFINED);
         BIND_ENUM_CONSTANT(POWER_SOURCE_INTERNAL);
@@ -124,27 +101,11 @@ namespace godot {
         return mover;
     }
 
-    void TrainController::set_train_id(const String &p_train_id) {
-        train_id = p_train_id;
-    }
-
-    String TrainController::get_train_id() const {
-        if (train_id.is_empty()) {
-            String new_id = get_name().to_lower();
-            if (new_id.is_empty()) {
-                new_id = "train";
-            }
-            return new_id;
-        }
-
-        return train_id;
-    }
-
     void TrainController::initialize_mover() {
         const auto initial_vel = this->initial_velocity;
-        const auto type_name = std::string(this->type_name.utf8().ptr());
+        const auto _type_name = std::string(type_name.utf8().ptr());
         const auto name = std::string(this->get_name().left(this->get_name().length()).utf8().ptr());
-        mover = std::make_unique<TMoverParameters>(initial_vel, type_name, name, this->cabin_number).release();
+        mover = std::make_unique<TMoverParameters>(initial_vel, _type_name, name, this->cabin_number).release();
 
         _dirty = true;
         _dirty_prop = true;
@@ -175,20 +136,12 @@ namespace godot {
         emit_signal(MOVER_INITIALIZED_SIGNAL);
     }
 
-    void TrainController::set_type_name(const String &p_type_name) {
-        type_name = p_type_name;
-    }
-
-    String TrainController::get_type_name() const {
-        return type_name;
-    }
-
     void TrainController::register_command(const String &command, const Callable &callable) {
-        TrainSystem::get_instance()->register_command(get_train_id(), command, callable);
+        TrainSystem::get_instance()->register_command(train_id, command, callable);
     }
 
     void TrainController::unregister_command(const String &command, const Callable &callable) {
-        TrainSystem::get_instance()->unregister_command(get_train_id(), command, callable);
+        TrainSystem::get_instance()->unregister_command(train_id, command, callable);
     }
 
     void TrainController::_notification(const int p_what) {
@@ -197,7 +150,7 @@ namespace godot {
         }
         switch (p_what) {
             case NOTIFICATION_ENTER_TREE:
-                TrainSystem::get_instance()->register_train(this->get_train_id(), this);
+                TrainSystem::get_instance()->register_train(train_id, this);
                 register_command("battery", Callable(this, "battery"));
                 register_command("main_controller_increase", Callable(this, "main_controller_increase"));
                 register_command("main_controller_decrease", Callable(this, "main_controller_decrease"));
@@ -218,7 +171,7 @@ namespace godot {
                 unregister_command("radio_channel_set", Callable(this, "radio_channel_set"));
                 unregister_command("radio_channel_increase", Callable(this, "radio_channel_increase"));
                 unregister_command("radio_channel_decrease", Callable(this, "radio_channel_decrease"));
-                TrainSystem::get_instance()->unregister_train(this->get_train_id());
+                TrainSystem::get_instance()->unregister_train(train_id);
                 break;
             case NOTIFICATION_READY:
                 initialize_mover();
@@ -314,50 +267,6 @@ namespace godot {
         config["axles_count"] = mover->NAxles;
     }
 
-    double TrainController::get_battery_voltage() const {
-        return battery_voltage;
-    }
-
-    void TrainController::set_battery_voltage(const double p_value) {
-        battery_voltage = p_value;
-        _dirty_prop = true;
-    }
-
-    void TrainController::set_mass(const double p_mass) {
-        mass = p_mass;
-        _dirty_prop = true;
-    }
-
-    double TrainController::get_mass() const {
-        return mass;
-    }
-
-    void TrainController::set_power(const double p_power) {
-        power = p_power;
-        _dirty_prop = true;
-    }
-
-    double TrainController::get_power() const {
-        return power;
-    }
-
-    void TrainController::set_max_velocity(const double p_value) {
-        max_velocity = p_value;
-        _dirty_prop = true;
-    }
-
-    double TrainController::get_max_velocity() const {
-        return max_velocity;
-    }
-
-    void TrainController::set_axle_arrangement(const String &p_value) {
-        axle_arrangement = p_value;
-    }
-
-    String TrainController::get_axle_arrangement() const {
-        return axle_arrangement;
-    }
-
     void TrainController::update_mover() {
         if (TMoverParameters *mover = get_mover(); mover != nullptr) {
             _do_update_internal_mover(mover);
@@ -379,22 +288,6 @@ namespace godot {
             UtilityFunctions::push_warning("TrainController::get_mover_state() failed: internal mover not initialized");
         }
         return internal_state;
-    }
-
-    int TrainController::get_radio_channel_min() const {
-        return radio_channel_min;
-    }
-
-    void TrainController::set_radio_channel_min(const int p_value) {
-        radio_channel_min = p_value;
-    }
-
-    int TrainController::get_radio_channel_max() const {
-        return radio_channel_max;
-    }
-
-    void TrainController::set_radio_channel_max(const int p_value) {
-        radio_channel_max = p_value;
     }
 
     void TrainController::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {
@@ -453,7 +346,7 @@ namespace godot {
     }
 
     void TrainController::send_command(const StringName &command, const Variant &p1, const Variant &p2) {
-        TrainSystem::get_instance()->send_command(this->get_train_id(), String(command), p1, p2);
+        TrainSystem::get_instance()->send_command(train_id, String(command), p1, p2);
     }
 
     void TrainController::battery(const bool p_enabled) {

--- a/src/core/TrainController.hpp
+++ b/src/core/TrainController.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../maszyna/McZapkie/MOVER.h"
+#include "macros.hpp"
 #include <godot_cpp/classes/node.hpp>
 
 
@@ -15,31 +16,19 @@ namespace godot {
             GDCLASS(TrainController, Node)
         private:
             TMoverParameters *mover{};
-            String train_id = "";
-
             double initial_velocity = 0.0;
             int cabin_number = 0;
-            String type_name = "";
             void initialize_mover();
             bool _dirty = false;      // Refreshes all elements
             bool _dirty_prop = false; // Refreshes only TrainController's properties
             Dictionary state;
             Dictionary config;
             Dictionary internal_state;
-
-            double battery_voltage = 0.0; // FIXME: move to TrainPower ?
-            double mass = 0.0;
-            double power = 0.0;
-            double max_velocity = 0.0;
             int radio_channel = 0;
-            int radio_channel_min = 0;
-            int radio_channel_max = 10;
 
             bool prev_is_powered = false;
             bool prev_radio_enabled = false;
             int prev_radio_channel = radio_channel;
-
-            String axle_arrangement = "";
 
             void _collect_train_parts(const Node *node, Vector<TrainPart *> &train_parts) {};
             void _update_mover_config_if_dirty();
@@ -150,24 +139,15 @@ namespace godot {
             void update_mover();
             TMoverParameters *get_mover() const;
             static void _bind_methods();
-            String get_train_id() const;
-            void set_train_id(const String &train_id);
-            String get_type_name() const;
-            void set_type_name(const String &type_name);
-            void set_battery_voltage(double p_value);
-            double get_battery_voltage() const;
-            void set_mass(double p_mass);
-            double get_mass() const;
-            void set_power(double p_power);
-            double get_power() const;
-            void set_max_velocity(double p_value);
-            double get_max_velocity() const;
-            void set_axle_arrangement(const String &p_value);
-            int get_radio_channel_min() const;
-            void set_radio_channel_min(int p_value);
-            int get_radio_channel_max() const;
-            void set_radio_channel_max(int p_value);
-            String get_axle_arrangement() const;
+            MAKE_MEMBER_GS(String, train_id, "");
+            MAKE_MEMBER_GS(String, type_name, "");
+            MAKE_MEMBER_GS_DIRTY(double, battery_voltage, 0.0); // FIXME: move to TrainPower ?
+            MAKE_MEMBER_GS(double, mass, 0.0);
+            MAKE_MEMBER_GS(double, power, 0.0);
+            MAKE_MEMBER_GS(double, max_velocity, 0.0);
+            MAKE_MEMBER_GS(String, axle_arrangement, "");
+            MAKE_MEMBER_GS(int, radio_channel_min, 0);
+            MAKE_MEMBER_GS(int, radio_channel_max, 0);
             Dictionary get_state();
     };
 } // namespace godot

--- a/src/doors/TrainDoors.cpp
+++ b/src/doors/TrainDoors.cpp
@@ -4,126 +4,33 @@
 namespace godot {
 
     void TrainDoors::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_type", "type"), &TrainDoors::set_type);
-        ClassDB::bind_method(D_METHOD("get_type"), &TrainDoors::get_type);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, "Shift,Rotate,Fold,Plug"), "set_type",
-                "get_type");
-        ClassDB::bind_method(D_METHOD("set_open_time", "open_time"), &TrainDoors::set_open_time);
-        ClassDB::bind_method(D_METHOD("get_open_time"), &TrainDoors::get_open_time);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "open/time"), "set_open_time", "get_open_time");
-        ClassDB::bind_method(D_METHOD("set_open_speed", "open_speed"), &TrainDoors::set_open_speed);
-        ClassDB::bind_method(D_METHOD("get_open_speed"), &TrainDoors::get_open_speed);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "open/speed"), "set_open_speed", "get_open_speed");
-        ClassDB::bind_method(D_METHOD("set_close_speed", "close_speed"), &TrainDoors::set_close_speed);
-        ClassDB::bind_method(D_METHOD("get_close_speed"), &TrainDoors::get_close_speed);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "close/speed"), "set_close_speed", "get_close_speed");
-        ClassDB::bind_method(D_METHOD("set_max_shift", "max_shift"), &TrainDoors::set_max_shift);
-        ClassDB::bind_method(D_METHOD("get_max_shift"), &TrainDoors::get_max_shift);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_shift"), "set_max_shift", "get_max_shift");
-        ClassDB::bind_method(D_METHOD("set_open_method", "open_method"), &TrainDoors::set_open_method);
-        ClassDB::bind_method(D_METHOD("get_open_method"), &TrainDoors::get_open_method);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "open/method", PROPERTY_HINT_ENUM, "Passenger,Automatic,Driver,Conductor,Mixed"),
-                "set_open_method", "get_open_method");
-        ClassDB::bind_method(D_METHOD("set_close_method", "close_method"), &TrainDoors::set_close_method);
-        ClassDB::bind_method(D_METHOD("get_close_method"), &TrainDoors::get_close_method);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "close/method", PROPERTY_HINT_ENUM, "Passenger,Automatic,Driver,Conductor,Mixed"),
-                "set_close_method", "get_close_method");
-        ClassDB::bind_method(D_METHOD("set_voltage", "voltage"), &TrainDoors::set_voltage);
-        ClassDB::bind_method(D_METHOD("get_voltage"), &TrainDoors::get_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "voltage", PROPERTY_HINT_ENUM, "Automatic,0V,12V,24V,112V"), "set_voltage",
-                "get_voltage");
-        ClassDB::bind_method(D_METHOD("set_close_warning", "close_warning"), &TrainDoors::set_close_warning);
-        ClassDB::bind_method(D_METHOD("get_close_warning"), &TrainDoors::get_close_warning);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "close/warning"), "set_close_warning", "get_close_warning");
-        ClassDB::bind_method(
-                D_METHOD("set_auto_close_warning", "auto_close_warning"), &TrainDoors::set_auto_close_warning);
-        ClassDB::bind_method(D_METHOD("get_auto_close_warning"), &TrainDoors::get_auto_close_warning);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "close/auto_close_warning"), "set_auto_close_warning",
-                "get_auto_close_warning");
-        ClassDB::bind_method(D_METHOD("set_open_delay", "open_delay"), &TrainDoors::set_open_delay);
-        ClassDB::bind_method(D_METHOD("get_open_delay"), &TrainDoors::get_open_delay);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "open/delay"), "set_open_delay", "get_open_delay");
-        ClassDB::bind_method(D_METHOD("set_close_delay", "close_delay"), &TrainDoors::set_close_delay);
-        ClassDB::bind_method(D_METHOD("get_close_delay"), &TrainDoors::get_close_delay);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "close/delay"), "set_close_delay", "get_close_delay");
-        ClassDB::bind_method(D_METHOD("set_open_with_permit", "holding_time"), &TrainDoors::set_open_with_permit);
-        ClassDB::bind_method(D_METHOD("get_open_with_permit"), &TrainDoors::get_open_with_permit);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "open/with_permit"), "set_open_with_permit", "get_open_with_permit");
-        ClassDB::bind_method(D_METHOD("set_has_lock", "lock"), &TrainDoors::set_has_lock);
-        ClassDB::bind_method(D_METHOD("get_has_lock"), &TrainDoors::get_has_lock);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_lock"), "set_has_lock", "get_has_lock");
-        ClassDB::bind_method(D_METHOD("set_max_shift_plug", "max_shift_plug"), &TrainDoors::set_max_shift_plug);
-        ClassDB::bind_method(D_METHOD("get_max_shift_plug"), &TrainDoors::get_max_shift_plug);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_shift_plug"), "set_max_shift_plug", "get_max_shift_plug");
-        ClassDB::bind_method(D_METHOD("set_permit_list", "permit_list"), &TrainDoors::set_permit_list);
-        ClassDB::bind_method(D_METHOD("get_permit_list"), &TrainDoors::get_permit_list);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::ARRAY, "permit/list", PROPERTY_HINT_ARRAY_TYPE), "set_permit_list",
-                "get_permit_list");
-        ClassDB::bind_method(
-                D_METHOD("set_permit_list_default", "permit_list_default"), &TrainDoors::set_permit_list_default);
-        ClassDB::bind_method(D_METHOD("get_permit_list_default"), &TrainDoors::get_permit_list_default);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "permit/list_default"), "set_permit_list_default",
-                "get_permit_list_default");
-        ClassDB::bind_method(
-                D_METHOD("set_auto_close_remote", "auto_close_remote"), &TrainDoors::set_auto_close_remote);
-        ClassDB::bind_method(D_METHOD("get_auto_close_remote"), &TrainDoors::get_auto_close_remote);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "close/auto_close_remote"), "set_auto_close_remote",
-                "get_auto_close_remote");
-        ClassDB::bind_method(
-                D_METHOD("set_auto_close_velocity", "auto_close_velocity"), &TrainDoors::set_auto_close_velocity);
-        ClassDB::bind_method(D_METHOD("get_auto_close_velocity"), &TrainDoors::get_auto_close_velocity);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "close/auto_close_velocity"), "set_auto_close_velocity",
-                "get_auto_close_velocity");
-        ClassDB::bind_method(
-                D_METHOD("set_platform_max_speed", "platform_max_speed"), &TrainDoors::set_platform_max_speed);
-        ClassDB::bind_method(D_METHOD("get_platform_max_speed"), &TrainDoors::get_platform_max_speed);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "platform/max_speed"), "set_platform_max_speed", "get_platform_max_speed");
-        ClassDB::bind_method(D_METHOD("set_platform_type", "platform_type"), &TrainDoors::set_platform_type);
-        ClassDB::bind_method(D_METHOD("get_platform_type"), &TrainDoors::get_platform_type);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "platform/type", PROPERTY_HINT_ENUM, "Shift,Rotate"), "set_platform_type",
-                "get_platform_type");
-        ClassDB::bind_method(
-                D_METHOD("set_platform_max_shift", "platform_max_shift"), &TrainDoors::set_platform_max_shift);
-        ClassDB::bind_method(D_METHOD("get_platform_max_shift"), &TrainDoors::get_platform_max_shift);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "platform/max_shift"), "set_platform_max_shift", "get_platform_max_shift");
-        ClassDB::bind_method(D_METHOD("set_platform_speed", "platform_speed"), &TrainDoors::set_platform_speed);
-        ClassDB::bind_method(D_METHOD("get_platform_speed"), &TrainDoors::get_platform_speed);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "platform/speed"), "set_platform_speed", "get_platform_speed");
-        ClassDB::bind_method(D_METHOD("set_mirror_max_shift", "mirror_max_shift"), &TrainDoors::set_mirror_max_shift);
-        ClassDB::bind_method(D_METHOD("get_mirror_max_shift"), &TrainDoors::get_mirror_max_shift);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mirror/max_shift"), "set_mirror_max_shift", "get_mirror_max_shift");
-        ClassDB::bind_method(
-                D_METHOD("set_mirror_close_velocity", "mirror_close_velocity"), &TrainDoors::set_mirror_close_velocity);
-        ClassDB::bind_method(D_METHOD("get_mirror_close_velocity"), &TrainDoors::get_mirror_close_velocity);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "mirror/close_velocity"), "set_mirror_close_velocity",
-                "get_mirror_close_velocity");
-        ClassDB::bind_method(D_METHOD("set_permit_required", "permit_required"), &TrainDoors::set_permit_required);
-        ClassDB::bind_method(D_METHOD("get_permit_required"), &TrainDoors::get_permit_required);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "permit/required"), "set_permit_required", "get_permit_required");
-        ClassDB::bind_method(
-                D_METHOD("set_permit_light_blinking", "blinking_mode"), &TrainDoors::set_permit_light_blinking);
-        ClassDB::bind_method(D_METHOD("get_permit_light_blinking"), &TrainDoors::get_permit_light_blinking);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "permit/light_blinking", PROPERTY_HINT_ENUM,
-                        "Continuous light,Flashing on permission w/step,Flashing on permission,Flashing always"),
-                "set_permit_light_blinking", "get_permit_light_blinking");
-
+        BIND_PROPERTY_W_HINT(Variant::INT, "type", "type", &TrainDoors::set_type, &TrainDoors::get_type, "type", PROPERTY_HINT_ENUM, "Shift,Rotate,Fold,Plug");
+        BIND_PROPERTY(Variant::FLOAT, "open_time", "open/time", &TrainDoors::set_open_time, &TrainDoors::get_open_time, "open_time");
+        BIND_PROPERTY(Variant::FLOAT, "open_speed", "open/speed", &TrainDoors::set_open_speed, &TrainDoors::get_open_speed, "open_speed");
+        BIND_PROPERTY(Variant::FLOAT, "close_speed", "close/speed", &TrainDoors::set_close_speed, &TrainDoors::get_close_speed, "close_speed");
+        BIND_PROPERTY(Variant::FLOAT, "max_shift", "max_shift", &TrainDoors::set_max_shift, &TrainDoors::get_max_shift, "max_shift");
+        BIND_PROPERTY_W_HINT(Variant::INT, "open_method", "open/method", &TrainDoors::set_open_method, &TrainDoors::get_open_method, "open_method", PROPERTY_HINT_ENUM, "Passenger,Automatic,Driver,Conductor,Mixed");
+        BIND_PROPERTY_W_HINT(Variant::INT, "close_method", "close/method", &TrainDoors::set_close_method, &TrainDoors::get_close_method, "close_method", PROPERTY_HINT_ENUM, "Passenger,Automatic,Driver,Conductor,Mixed");
+        BIND_PROPERTY_W_HINT(Variant::INT, "voltage", "voltage", &TrainDoors::set_voltage, &TrainDoors::get_voltage, "voltage", PROPERTY_HINT_ENUM, "Automatic,0V,12V,24V,112V");
+        BIND_PROPERTY(Variant::BOOL, "close_warning", "close/warning", &TrainDoors::set_close_warning, &TrainDoors::get_close_warning, "close_warning");
+        BIND_PROPERTY(Variant::BOOL, "auto_close_warning", "close/auto_close_warning", &TrainDoors::set_auto_close_warning, &TrainDoors::get_auto_close_warning, "auto_close_warning");
+        BIND_PROPERTY(Variant::FLOAT, "open_delay", "open/delay", &TrainDoors::set_open_delay, &TrainDoors::get_open_delay, "open_delay");
+        BIND_PROPERTY(Variant::FLOAT, "close_delay", "close/delay", &TrainDoors::set_close_delay, &TrainDoors::get_close_delay, "close_delay");
+        BIND_PROPERTY(Variant::FLOAT, "open_with_permit", "open/with_permit", &TrainDoors::set_open_with_permit, &TrainDoors::get_open_with_permit, "open_with_permit");
+        BIND_PROPERTY(Variant::BOOL, "has_lock", "has_lock", &TrainDoors::set_has_lock, &TrainDoors::get_has_lock, "has_lock");
+        BIND_PROPERTY(Variant::FLOAT, "max_shift_plug", "max_shift_plug", &TrainDoors::set_max_shift_plug, &TrainDoors::get_max_shift_plug, "max_shift_plug");
+        BIND_PROPERTY_ARRAY("permit_list", "permit/list", &TrainDoors::set_permit_list, &TrainDoors::get_permit_list, "permit_list");
+        BIND_PROPERTY(Variant::INT, "permit_default", "permit/default", &TrainDoors::set_permit_list_default, &TrainDoors::get_permit_list_default, "permit_default");
+        BIND_PROPERTY(Variant::BOOL, "auto_close_remote", "close/auto_close_remote", &TrainDoors::set_auto_close_remote, &TrainDoors::get_auto_close_remote, "auto_close_remote");
+        BIND_PROPERTY(Variant::FLOAT, "auto_close_velocity", "close/auto_close_velocity", &TrainDoors::set_auto_close_velocity, &TrainDoors::get_auto_close_velocity, "auto_close_velocity");
+        BIND_PROPERTY(Variant::FLOAT, "platform_max_speed", "platform/max_speed", &TrainDoors::set_platform_max_speed, &TrainDoors::get_platform_max_speed, "platform_max_speed");
+        BIND_PROPERTY_W_HINT(Variant::INT, "platform_type", "platform/type", &TrainDoors::set_platform_type, &TrainDoors::get_platform_type, "platform_type", PROPERTY_HINT_ENUM, "Shift,Rotate");
+        BIND_PROPERTY(Variant::FLOAT, "platform_max_shift", "platform/max_shift", &TrainDoors::set_platform_max_shift, &TrainDoors::get_platform_max_shift, "platform_max_shift");
+        BIND_PROPERTY(Variant::FLOAT, "platform_speed", "platform/speed", &TrainDoors::set_platform_speed, &TrainDoors::get_platform_speed, "platform_speed");
+        BIND_PROPERTY(Variant::FLOAT, "mirror_max_shift", "mirror/max_shift", &TrainDoors::set_mirror_max_shift, &TrainDoors::get_mirror_max_shift, "mirror_max_shift");
+        BIND_PROPERTY(Variant::FLOAT, "mirror_close_velocity", "mirror/close_velocity", &TrainDoors::set_mirror_close_velocity, &TrainDoors::get_mirror_close_velocity, "mirror_close_velocity");
+        BIND_PROPERTY(Variant::BOOL, "permit_required", "permit/required", &TrainDoors::set_permit_required, &TrainDoors::get_permit_required, "permit_required");
+        BIND_PROPERTY_W_HINT(Variant::INT, "permit_light_blinking", "permit/light_blinking", &TrainDoors::set_permit_light_blinking, &TrainDoors::get_permit_light_blinking, "permit_light_blinking", PROPERTY_HINT_ENUM, "Continuous light,Flashing on permission w/step,Flashing on permission,Flashing always");
         ClassDB::bind_method(D_METHOD("next_permit_preset"), &TrainDoors::next_permit_preset);
         ClassDB::bind_method(D_METHOD("previous_permit_preset"), &TrainDoors::previous_permit_preset);
         ClassDB::bind_method(D_METHOD("permit_step", "state"), &TrainDoors::permit_step);
@@ -285,13 +192,13 @@ namespace godot {
         if (doorControlsMap.find(open_method) != doorControlsMap.end()) {
             mover->Doors.open_control = doorControlsMap.at(open_method);
         } else {
-            log_error("Unhandled door open controls position: " + String::num(static_cast<int>(open_method)));
+            log_error("Unhandled door open controls position: " + String::num(open_method));
         }
 
         if (doorControlsMap.find(close_method) != doorControlsMap.end()) {
             mover->Doors.close_control = doorControlsMap.at(close_method);
         } else {
-            log_error("Unhandled door close controls position: " + String::num(static_cast<int>(close_method)));
+            log_error("Unhandled door close controls position: " + String::num(close_method));
         }
 
         mover->Doors.auto_duration = open_time;
@@ -321,7 +228,7 @@ namespace godot {
         if (doorTypeMap.find(type) != doorTypeMap.end()) {
             mover->Doors.type = doorTypeMap.at(type);
         } else {
-            log_error("Unhandled door type: " + String::num(static_cast<int>(type)));
+            log_error("Unhandled door type: " + String::num(type));
         }
 
         mover->Doors.has_warning = close_warning;
@@ -346,248 +253,5 @@ namespace godot {
         mover->MirrorVelClose = mirror_close_velocity;
         mover->DoorsOpenWithPermitAfter = open_with_permit;
         mover->DoorsPermitLightBlinking = permit_light_blinking;
-    }
-
-    void TrainDoors::set_type(const Type p_type) {
-        type = p_type;
-        _dirty = true;
-    }
-
-    TrainDoors::Type TrainDoors::get_type() const {
-        return type;
-    }
-
-    void TrainDoors::set_open_time(const float p_value) {
-        open_time = p_value;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_open_time() const {
-        return open_time;
-    }
-
-    void TrainDoors::set_open_speed(const float p_value) {
-        open_speed = p_value;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_open_speed() const {
-        return open_speed;
-    }
-
-    void TrainDoors::set_close_speed(const float p_value) {
-        close_speed = p_value;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_close_speed() const {
-        return close_speed;
-    }
-
-    void TrainDoors::set_max_shift(const float p_max_shift) {
-        max_shift = p_max_shift;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_max_shift() const {
-        return max_shift;
-    }
-
-    void TrainDoors::set_open_method(const Controls p_open_method) {
-        open_method = p_open_method;
-        _dirty = true;
-    }
-
-    TrainDoors::Controls TrainDoors::get_open_method() const {
-        return open_method;
-    }
-
-    void TrainDoors::set_close_method(const Controls p_close_method) {
-        close_method = p_close_method;
-        _dirty = true;
-    }
-
-    TrainDoors::Controls TrainDoors::get_close_method() const {
-        return close_method;
-    }
-
-    void TrainDoors::set_voltage(const Voltage p_voltage) {
-        voltage = p_voltage;
-        _dirty = true;
-    }
-
-    TrainDoors::Voltage TrainDoors::get_voltage() const {
-        return voltage;
-    }
-
-    void TrainDoors::set_close_warning(const bool p_close_warning) {
-        close_warning = p_close_warning;
-        _dirty = true;
-    }
-
-    bool TrainDoors::get_close_warning() const {
-        return close_warning;
-    }
-
-    void TrainDoors::set_auto_close_warning(const bool p_auto_close_warning) {
-        auto_close_warning = p_auto_close_warning;
-        _dirty = true;
-    }
-
-    bool TrainDoors::get_auto_close_warning() const {
-        return auto_close_warning;
-    }
-
-    void TrainDoors::set_open_delay(const float p_open_delay) {
-        open_delay = p_open_delay;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_open_delay() const {
-        return open_delay;
-    }
-
-    void TrainDoors::set_close_delay(const float p_close_delay) {
-        close_delay = p_close_delay;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_close_delay() const {
-        return close_delay;
-    }
-
-    void TrainDoors::set_open_with_permit(const float p_holding_time) {
-        open_with_permit = p_holding_time;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_open_with_permit() const {
-        return open_with_permit;
-    }
-
-    void TrainDoors::set_has_lock(const bool p_has_lock) {
-        has_lock = p_has_lock;
-        _dirty = true;
-    }
-
-    bool TrainDoors::get_has_lock() const {
-        return has_lock;
-    }
-
-    void TrainDoors::set_max_shift_plug(const float p_max_shift_plug) {
-        max_shift = p_max_shift_plug;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_max_shift_plug() const {
-        return max_shift;
-    }
-
-    void TrainDoors::set_permit_list(const Array &p_permit_list) {
-        permit_list = p_permit_list;
-        _dirty = true;
-    }
-
-    Array TrainDoors::get_permit_list() const {
-        return permit_list;
-    }
-
-    void TrainDoors::set_permit_list_default(const int p_permit_list_default) {
-        permit_list_default = p_permit_list_default;
-        _dirty = true;
-    }
-
-    int TrainDoors::get_permit_list_default() const {
-        return permit_list_default;
-    }
-
-    void TrainDoors::set_auto_close_remote(const bool p_auto_close) {
-        auto_close_remote = p_auto_close;
-        _dirty = true;
-    }
-
-    bool TrainDoors::get_auto_close_remote() const {
-        return auto_close_remote;
-    }
-
-    void TrainDoors::set_auto_close_velocity(const float p_vel) {
-        auto_close_velocity = p_vel;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_auto_close_velocity() const {
-        return auto_close_velocity;
-    }
-
-    void TrainDoors::set_platform_max_speed(const double p_max_speed) {
-        platform_max_speed = p_max_speed;
-        _dirty = true;
-    }
-
-    double TrainDoors::get_platform_max_speed() const {
-        return platform_max_speed;
-    }
-
-    void TrainDoors::set_platform_max_shift(const float p_max_shift) {
-        platform_max_shift = p_max_shift;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_platform_max_shift() const {
-        return platform_max_shift;
-    }
-
-    void TrainDoors::set_platform_speed(const float p_speed) {
-        platform_speed = p_speed;
-        _dirty = true;
-    }
-
-    float TrainDoors::get_platform_speed() const {
-        return platform_speed;
-    }
-
-    void TrainDoors::set_platform_type(const PlatformType p_type) {
-        platform_type = p_type;
-        _dirty = true;
-    }
-
-    TrainDoors::PlatformType TrainDoors::get_platform_type() const {
-        return platform_type;
-    }
-
-    void TrainDoors::set_mirror_max_shift(const double p_max_shift) {
-        mirror_max_shift = p_max_shift;
-        _dirty = true;
-    }
-
-    double TrainDoors::get_mirror_max_shift() const {
-        return mirror_max_shift;
-    }
-
-    void TrainDoors::set_mirror_close_velocity(const double p_close_velocity) {
-        mirror_close_velocity = p_close_velocity;
-        _dirty = true;
-    }
-
-    double TrainDoors::get_mirror_close_velocity() const {
-        return mirror_close_velocity;
-    }
-
-    void TrainDoors::set_permit_required(const bool p_permit_required) {
-        permit_required = p_permit_required;
-        _dirty = true;
-    }
-
-    bool TrainDoors::get_permit_required() const {
-        return permit_required;
-    }
-
-    void TrainDoors::set_permit_light_blinking(const PermitLight p_blinking_mode) {
-        permit_light_blinking = p_blinking_mode;
-        _dirty = true;
-    }
-
-    TrainDoors::PermitLight TrainDoors::get_permit_light_blinking() const {
-        return permit_light_blinking;
     }
 } // namespace godot

--- a/src/doors/TrainDoors.hpp
+++ b/src/doors/TrainDoors.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../core/TrainPart.hpp"
+#include "macros.hpp"
 
 namespace godot {
     class TrainController;
@@ -46,61 +47,6 @@ namespace godot {
             };
 
             static void _bind_methods();
-            void set_type(Type p_type);
-            Type get_type() const;
-            void set_open_time(float p_value);
-            float get_open_time() const;
-            void set_open_speed(float p_value);
-            float get_open_speed() const;
-            void set_close_speed(float p_value);
-            float get_close_speed() const;
-            void set_max_shift(float p_max_shift);
-            float get_max_shift() const;
-            void set_open_method(Controls p_open_method);
-            Controls get_open_method() const;
-            void set_close_method(Controls p_close_method);
-            Controls get_close_method() const;
-            void set_voltage(Voltage p_voltage);
-            Voltage get_voltage() const;
-            void set_close_warning(bool p_close_warning);
-            bool get_close_warning() const;
-            void set_auto_close_warning(bool p_auto_close_warning);
-            bool get_auto_close_warning() const;
-            void set_open_delay(float p_open_delay);
-            float get_open_delay() const;
-            void set_close_delay(float p_close_delay);
-            float get_close_delay() const;
-            void set_open_with_permit(float p_holding_time);
-            float get_open_with_permit() const;
-            void set_has_lock(bool p_has_lock);
-            bool get_has_lock() const;
-            void set_max_shift_plug(float p_max_shift_plug);
-            float get_max_shift_plug() const;
-            void set_permit_list(const Array &p_permit_list);
-            Array get_permit_list() const;
-            void set_permit_list_default(int p_permit_list_default);
-            int get_permit_list_default() const;
-            void set_auto_close_remote(bool p_auto_close);
-            bool get_auto_close_remote() const;
-            void set_auto_close_velocity(float p_vel);
-            float get_auto_close_velocity() const;
-            void set_platform_max_speed(double p_max_speed);
-            double get_platform_max_speed() const;
-            void set_platform_max_shift(float p_max_shift);
-            float get_platform_max_shift() const;
-            void set_platform_speed(float p_speed);
-            float get_platform_speed() const;
-            void set_platform_type(PlatformType p_type);
-            PlatformType get_platform_type() const;
-            void set_mirror_max_shift(double p_max_shift);
-            double get_mirror_max_shift() const;
-            void set_mirror_close_velocity(double p_close_velocity);
-            double get_mirror_close_velocity() const;
-            void set_permit_required(bool p_permit_required);
-            bool get_permit_required() const;
-            void set_permit_light_blinking(PermitLight p_blinking_mode);
-            PermitLight get_permit_light_blinking() const;
-
             void permit_step(bool p_state);
             void permit_doors(Side p_side, bool p_state);
             void permit_left_doors(bool p_state);
@@ -115,8 +61,8 @@ namespace godot {
 
         private:
             // Maszyna Mover has no consts for voltages
-            const std::map<Voltage, float> voltageMap = {//@FIXME: MSVC complains about float <-> int conversion and possible data loss. See parser for reference
-                    {VOLTAGE_0, 0}, {VOLTAGE_12, 12}, {VOLTAGE_24, 24}, {VOLTAGE_112, 112}};
+            const std::map<Voltage, float> voltageMap = {
+                    {VOLTAGE_0, 0.0f}, {VOLTAGE_12, 12.0f}, {VOLTAGE_24, 24.0f}, {VOLTAGE_112, 112.0f}};
 
             // Maszyna Mover has no consts for door types
             const std::map<Type, int> doorTypeMap = {{TYPE_SHIFT, 1}, {TYPE_ROTATE, 2}, {TYPE_FOLD, 3}, {TYPE_PLUG, 4}};
@@ -140,146 +86,34 @@ namespace godot {
                     {Controls::CONTROLS_MIXED, Maszyna::control_t::mixed},
             };
 
-            /**
-             * Type of the door. Default value from internal mover
-             *
-             */
-            Type type = Type::TYPE_ROTATE;
-            /**
-             * The type of door (opening method). Default value from internal mover
-             */
-            Controls open_method = Controls::CONTROLS_PASSENGER;
-
-            /**
-             * The type of door (closing method). Default value from internal mover
-             */
-            Controls close_method = Controls::CONTROLS_PASSENGER;
-
-            /**
-             * Time period for which door would stay opened. Default value from internal mover
-             */
-            float open_time = -1.0f;
-
-            /**
-             * Speed of opening the doors. Default value from internal mover
-             */
-            float open_speed = 1.0f;
-
-            /**
-             * Speed of closing the door. Default value from internal mover
-             */
-            float close_speed = 1.0f;
-
-            /**
-             * The width (or angle) of the door fully opening. Default value from internal mover
-             */
-            float max_shift = 0.5f;
-
-            /**
-             * Low voltage circuit voltage required for door control. Default value from internal mover
-             */
-            Voltage voltage = Voltage::VOLTAGE_AUTO;
-
-            /**
-             * Buzzer before closing the door. Default value from internal mover
-             */
-            bool close_warning = false;
-
-            /**
-             * When you press the door closing button, a buzzer is activated, when you release it, the door closes.
-             * Default value from internal mover
-             */
-            bool auto_close_warning = false;
-
-            /**
-             * TrainDoors closing delay, in seconds. Default value from internal mover
-             */
-            float close_delay = 0.0;
-
-            /**
-             * TrainDoors opening delay, in seconds. Default value from internal mover
-             */
-            float open_delay = 0.0;
-
-            /**
-             * Opening a train door by holding the impulse opening permission button, in seconds of holding the button
-             */
-            float open_with_permit = -1.0f;
-
-            /**
-             * Indicates whether the train door has lock. Defaults to false.
-             */
-            bool has_lock = false;
-
-            /**
-             * The amount of rebound for Plug type doors (rebound-sliding), in meters. Default value from internal mover
-             */
-            float max_shift_plug = 0.1f;
-
-            /**
-             * TrainDoors programmer configuration. Number in the range of 0-3 where 0=no permissions, 1=allows left
-             * door operation, 2=right door, 3=all
-             */
-            Array permit_list = Array({"0", "0", "0"});
-
-            /**
-             * The default knob position is from the set defined by the permit_list entry; positions are numbered
-             * from 1. Default value from internal mover
-             */
-            int permit_list_default = 1;
-
-            /**
-             * Automatic closing of centrally opened doors after time has elapsed
-             */
-            bool auto_close_remote = false;
-
-            /**
-             * The speed at which the door automatically closes. Default value from internal mover
-             */
-            float auto_close_velocity = -1.0f;
-
-            /**
-             * Docs do not describe this properly. Need to figure this out
-             */
-            double platform_max_speed = 0.0;
-
-            /**
-             * Offset value in meters or rotation angle for a fully extended step. Default value from internal mover
-             */
-            float platform_max_shift = 0.0f;
-
-            /**
-             * The speed of the animation step, where 1.0 corresponds to an animation lasting one second, a value of 0.5
-             * to two seconds, etc. Default value from internal mover
-             */
-            float platform_speed = 0.5f;
-
-            /**
-             * Rotation angle for fully extended mirror
-             */
-            double mirror_max_shift = 90.0;
-
-            /**
-             * The speed of the traction vehicle at which the external mirrors are automatically closed
-             */
-            double mirror_close_velocity = 5.0;
-
-            /**
-             * Opening doors by passengers requires the train driver's consent. Default value from internal mover
-             */
-            bool permit_required = false;
-
-            /**
-             * Blinking permit light. Default value from internal mover
-             */
-            PermitLight permit_light_blinking = PermitLight::PERMIT_LIGHT_CONTINUOUS;
-
-            PlatformType platform_type = PlatformType::PLATFORM_TYPE_ROTATE;
-
-            /**
-             * Describes the side where the doors are placed
-             */
-            Side side = Side::SIDE_LEFT;
+            MAKE_MEMBER_GS_NR(Type, type, Type::TYPE_ROTATE);
+            MAKE_MEMBER_GS_NR(Controls, open_method, Controls::CONTROLS_PASSENGER);
+            MAKE_MEMBER_GS_NR(Controls, close_method, Controls::CONTROLS_PASSENGER);
+            MAKE_MEMBER_GS(float, open_time, -1.0f);
+            MAKE_MEMBER_GS(float, open_speed, 1.0f);
+            MAKE_MEMBER_GS(float, close_speed, 1.0f);
+            MAKE_MEMBER_GS(float, max_shift, 0.5f);
+            MAKE_MEMBER_GS_NR(Voltage, voltage, Voltage::VOLTAGE_AUTO);
+            MAKE_MEMBER_GS(bool, close_warning, false);
+            MAKE_MEMBER_GS(bool, auto_close_warning, false);
+            MAKE_MEMBER_GS(float, close_delay, 0.0f);
+            MAKE_MEMBER_GS(float, open_delay, 0.0f);
+            MAKE_MEMBER_GS(float, open_with_permit, -1.0f);
+            MAKE_MEMBER_GS_DIRTY(bool, has_lock, false);
+            MAKE_MEMBER_GS(float, max_shift_plug, 0.1f);
+            MAKE_MEMBER_GS(Array, permit_list, Array({"0", "0", "0"}));
+            MAKE_MEMBER_GS(int, permit_list_default, 1);
+            MAKE_MEMBER_GS(bool, auto_close_remote, false);
+            MAKE_MEMBER_GS(float, auto_close_velocity, -1.0f);
+            MAKE_MEMBER_GS(double, platform_max_speed, 0.0);
+            MAKE_MEMBER_GS(float, platform_max_shift, 0.0f);
+            MAKE_MEMBER_GS_DIRTY(float, platform_speed, 0.5f);
+            MAKE_MEMBER_GS(double, mirror_max_shift, 90.0);
+            MAKE_MEMBER_GS(double, mirror_close_velocity, 5.0);
+            MAKE_MEMBER_GS_DIRTY(bool, permit_required, false);
+            MAKE_MEMBER_GS_NR(PermitLight, permit_light_blinking, PermitLight::PERMIT_LIGHT_CONTINUOUS);
+            MAKE_MEMBER_GS_NR(PlatformType, platform_type, PlatformType::PLATFORM_TYPE_ROTATE);
+            MAKE_MEMBER_GS_NR(Side, side, Side::SIDE_LEFT);
     };
 } // namespace godot
 

--- a/src/engines/TrainDieselEngine.cpp
+++ b/src/engines/TrainDieselEngine.cpp
@@ -1,34 +1,18 @@
 #include "TrainDieselEngine.hpp"
+#include "macros.hpp"
+
 #include <godot_cpp/classes/gd_extension.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 namespace godot {
     void TrainDieselEngine::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("get_oil_min_pressure"), &TrainDieselEngine::get_oil_min_pressure);
-        ClassDB::bind_method(D_METHOD("set_oil_min_pressure", "value"), &TrainDieselEngine::set_oil_min_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "oil_pump/pressure_minimum"), "set_oil_min_pressure",
-                "get_oil_min_pressure");
-
-        ClassDB::bind_method(D_METHOD("get_oil_max_pressure"), &TrainDieselEngine::get_oil_max_pressure);
-        ClassDB::bind_method(D_METHOD("set_oil_max_pressure", "value"), &TrainDieselEngine::set_oil_max_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "oil_pump/pressure_maximum"), "set_oil_max_pressure",
-                "get_oil_max_pressure");
-
-        ClassDB::bind_method(D_METHOD("get_traction_force_max"), &TrainDieselEngine::get_traction_force_max);
-        ClassDB::bind_method(D_METHOD("set_traction_force_max", "value"), &TrainDieselEngine::set_traction_force_max);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "Ftmax"), "set_traction_force_max", "get_traction_force_max");
-
-        ClassDB::bind_method(D_METHOD("set_wwlist"), &TrainDieselEngine::set_wwlist);
-        ClassDB::bind_method(D_METHOD("get_wwlist"), &TrainDieselEngine::get_wwlist);
+        BIND_PROPERTY(Variant::FLOAT, "oil_min_pressure", "oil_pump/pressure_minimum", &TrainDieselEngine::set_oil_min_pressure, &TrainDieselEngine::get_oil_min_pressure, "oil_min_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "oil_max_pressure", "oil_pump/pressure_maximum", &TrainDieselEngine::set_oil_max_pressure, &TrainDieselEngine::get_oil_max_pressure, "oil_max_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "maximum_traction_force", "maximum_traction_force", &TrainDieselEngine::set_traction_force_max, &TrainDieselEngine::get_traction_force_max, "maximum_traction_force");
+        BIND_PROPERTY_W_HINT_RES_ARRAY(Variant::ARRAY, "wwlist", "wwlist", &TrainDieselEngine::set_wwlist, &TrainDieselEngine::get_wwlist, "wwlist", PROPERTY_HINT_TYPE_STRING, "WWListItem");
         ClassDB::bind_method(D_METHOD("fuel_pump", "enabled"), &TrainDieselEngine::fuel_pump);
         ClassDB::bind_method(D_METHOD("oil_pump", "enabled"), &TrainDieselEngine::oil_pump);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::ARRAY, "wwlist", PROPERTY_HINT_TYPE_STRING, String::num(Variant::OBJECT) + "/" + String::num(PROPERTY_HINT_RESOURCE_TYPE) + ":WWListItem", PROPERTY_USAGE_DEFAULT, "TypedArray<WWListItem>"),
-                "set_wwlist", "get_wwlist");
     }
 
     TrainEngine::EngineType TrainDieselEngine::get_engine_type() {
@@ -79,54 +63,18 @@ namespace godot {
                 return;
             }
 
-            mover->DElist[i].RPM = row->rpm;
-            mover->DElist[i].GenPower = row->max_power;
-            mover->DElist[i].Umax = row->max_voltage;
-            mover->DElist[i].Imax = row->max_current;
-            if (row->has_shunting) {
-                mover->SST[i].Umin = row->min_wakeup_voltage;
-                mover->SST[i].Umax = row->max_wakeup_voltage;
-                mover->SST[i].Pmax = row->max_wakeup_power;
+            mover->DElist[i].RPM = row->get_rpm();
+            mover->DElist[i].GenPower = row->get_max_power();
+            mover->DElist[i].Umax = row->get_max_voltage();
+            mover->DElist[i].Imax = row->get_max_current();
+            if (row->get_has_shunting()) {
+                mover->SST[i].Umin = row->get_min_wakeup_voltage();
+                mover->SST[i].Umax = row->get_max_wakeup_voltage();
+                mover->SST[i].Pmax = row->get_max_wakeup_power();
                 mover->SST[i].Pmin = std::sqrt(std::pow(mover->SST[i].Umin, 2) / 47.6);
                 mover->SST[i].Pmax = std::min(mover->SST[i].Pmax, std::pow(mover->SST[i].Umax, 2) / 47.6);
             }
         }
-    }
-
-    double TrainDieselEngine::get_oil_min_pressure() const {
-        return oil_min_pressure;
-    }
-
-    void TrainDieselEngine::set_oil_min_pressure(const float value) {
-        oil_min_pressure = value;
-        _dirty = true;
-    }
-
-    double TrainDieselEngine::get_oil_max_pressure() const {
-        return oil_max_pressure;
-    }
-
-    void TrainDieselEngine::set_oil_max_pressure(const float value) {
-        oil_max_pressure = value;
-        _dirty = true;
-    }
-
-    double TrainDieselEngine::get_traction_force_max() const {
-        return traction_force_max;
-    }
-
-    void TrainDieselEngine::set_traction_force_max(const double value) {
-        traction_force_max = value;
-        _dirty = true;
-    }
-
-    TypedArray<WWListItem> TrainDieselEngine::get_wwlist() {
-        return wwlist;
-    }
-
-    void TrainDieselEngine::set_wwlist(const TypedArray<WWListItem>& p_wwlist) {
-        wwlist.clear();
-        wwlist.append_array(p_wwlist);
     }
 
     void TrainDieselEngine::oil_pump(const bool p_enabled) {

--- a/src/engines/TrainDieselEngine.hpp
+++ b/src/engines/TrainDieselEngine.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "../maszyna/McZapkie/MOVER.h"
 #include "TrainEngine.hpp"
+#include "macros.hpp"
 #include "resources/engines/WWListItem.hpp"
-
 
 namespace godot {
     class TrainController;
@@ -11,10 +11,9 @@ namespace godot {
             GDCLASS(TrainDieselEngine, TrainEngine)
         private:
             static void _bind_methods();
-            float oil_min_pressure = 0.0;   // OilMinPressure -> OilPump.pressure_minimum
-            float oil_max_pressure = 0.65;  // OilMaxPressure -> OilPump.pressure_maximum
-            double traction_force_max = 0.0; // Ftmax -> Ftmax
-
+            MAKE_MEMBER_GS(float, oil_min_pressure, 0.0);
+            MAKE_MEMBER_GS(float, oil_max_pressure, 0.65);
+            MAKE_MEMBER_GS(double, traction_force_max, 0.0);
             TypedArray<WWListItem> wwlist;
 
         protected:
@@ -26,17 +25,14 @@ namespace godot {
 
 
         public:
-            double get_oil_min_pressure() const;
-            void set_oil_min_pressure(float value);
+            TypedArray<WWListItem> get_wwlist() {
+                return wwlist;
+            }
 
-            double get_oil_max_pressure() const;
-            void set_oil_max_pressure(float value);
-
-            double get_traction_force_max() const;
-            void set_traction_force_max(double value);
-
-            TypedArray<WWListItem> get_wwlist();
-            void set_wwlist(const TypedArray<WWListItem> &p_wwlist);
+            void set_wwlist(const TypedArray<WWListItem>& p_wwlist) {
+                wwlist.clear();
+                wwlist.append_array(p_wwlist);
+            }
 
             void oil_pump(bool p_enabled);
             void fuel_pump(bool p_enabled);

--- a/src/engines/TrainElectricEngine.cpp
+++ b/src/engines/TrainElectricEngine.cpp
@@ -1,137 +1,33 @@
 #include "TrainElectricEngine.hpp"
+#include "macros.hpp"
+
 #include <godot_cpp/classes/gd_extension.hpp>
 #include <godot_cpp/classes/node.hpp>
 
 namespace godot {
     void TrainElectricEngine::_bind_methods() {
-
-        ClassDB::bind_method(D_METHOD("set_engine_power_source"), &TrainElectricEngine::set_engine_power_source);
-        ClassDB::bind_method(D_METHOD("get_engine_power_source"), &TrainElectricEngine::get_engine_power_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "power/source", PROPERTY_HINT_ENUM,
-                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
-                        "Main"),
-                "set_engine_power_source", "get_engine_power_source");
-
-        ClassDB::bind_method(D_METHOD("set_number_of_collectors"), &TrainElectricEngine::set_number_of_collectors);
-        ClassDB::bind_method(D_METHOD("get_number_of_collectors"), &TrainElectricEngine::get_number_of_collectors);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "power/current_collector/number_of_collectors"), "set_number_of_collectors",
-                "get_number_of_collectors");
-
-        ClassDB::bind_method(D_METHOD("set_max_voltage"), &TrainElectricEngine::set_max_voltage);
-        ClassDB::bind_method(D_METHOD("get_max_voltage"), &TrainElectricEngine::get_max_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/max_voltage"), "set_max_voltage",
-                "get_max_voltage");
-
-        ClassDB::bind_method(D_METHOD("set_max_current"), &TrainElectricEngine::set_max_current);
-        ClassDB::bind_method(D_METHOD("get_max_current"), &TrainElectricEngine::get_max_current);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/max_current"), "set_max_current",
-                "get_max_current");
-
-        ClassDB::bind_method(D_METHOD("set_max_collector_lifting"), &TrainElectricEngine::set_max_collector_lifting);
-        ClassDB::bind_method(D_METHOD("get_max_collector_lifting"), &TrainElectricEngine::get_max_collector_lifting);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/max_collector_lifting"),
-                "set_max_collector_lifting", "get_max_collector_lifting");
-
-        ClassDB::bind_method(D_METHOD("set_min_collector_lifting"), &TrainElectricEngine::set_min_collector_lifting);
-        ClassDB::bind_method(D_METHOD("get_min_collector_lifting"), &TrainElectricEngine::get_min_collector_lifting);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/min_collector_lifting"),
-                "set_min_collector_lifting", "get_min_collector_lifting");
-
-        ClassDB::bind_method(D_METHOD("set_csw"), &TrainElectricEngine::set_csw);
-        ClassDB::bind_method(D_METHOD("get_csw"), &TrainElectricEngine::get_csw);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/collector_sliding_width"), "set_csw", "get_csw");
-
-        ClassDB::bind_method(
-                D_METHOD("set_min_main_switch_voltage"), &TrainElectricEngine::set_min_main_switch_voltage);
-        ClassDB::bind_method(
-                D_METHOD("get_min_main_switch_voltage"), &TrainElectricEngine::get_min_main_switch_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/min_main_switch_voltage"),
-                "set_min_main_switch_voltage", "get_min_main_switch_voltage");
-
-        ClassDB::bind_method(
-                D_METHOD("set_min_pantograph_tank_pressure"), &TrainElectricEngine::set_min_pantograph_tank_pressure);
-        ClassDB::bind_method(
-                D_METHOD("get_min_pantograph_tank_pressure"), &TrainElectricEngine::get_min_pantograph_tank_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/min_pantograph_tank_pressure"),
-                "set_min_pantograph_tank_pressure", "get_min_pantograph_tank_pressure");
-
-        ClassDB::bind_method(
-                D_METHOD("set_max_pantograph_tank_pressure"), &TrainElectricEngine::set_max_pantograph_tank_pressure);
-        ClassDB::bind_method(
-                D_METHOD("get_max_pantograph_tank_pressure"), &TrainElectricEngine::get_max_pantograph_tank_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/max_pantograph_tank_pressure"),
-                "set_max_pantograph_tank_pressure", "get_max_pantograph_tank_pressure");
-
-        ClassDB::bind_method(D_METHOD("set_overvoltage_relay"), &TrainElectricEngine::set_overvoltage_relay);
-        ClassDB::bind_method(D_METHOD("get_overvoltage_relay"), &TrainElectricEngine::get_overvoltage_relay);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "power/current_collector/overvoltage_relay"), "set_overvoltage_relay",
-                "get_overvoltage_relay");
-
-        ClassDB::bind_method(
-                D_METHOD("set_required_main_switch_voltage"), &TrainElectricEngine::set_required_main_switch_voltage);
-        ClassDB::bind_method(
-                D_METHOD("get_required_main_switch_voltage"), &TrainElectricEngine::get_required_main_switch_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/current_collector/required_main_switch_voltage"),
-                "set_required_main_switch_voltage", "get_required_main_switch_voltage");
-
-        ClassDB::bind_method(
-                D_METHOD("set_transducer_input_voltage"), &TrainElectricEngine::set_transducer_input_voltage);
-        ClassDB::bind_method(
-                D_METHOD("get_transducer_input_voltage"), &TrainElectricEngine::get_transducer_input_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/transducer/input_voltage"), "set_transducer_input_voltage",
-                "get_transducer_input_voltage");
-
-        ClassDB::bind_method(
-                D_METHOD("set_accumulator_recharge_source"), &TrainElectricEngine::set_accumulator_recharge_source);
-        ClassDB::bind_method(
-                D_METHOD("get_accumulator_recharge_source"), &TrainElectricEngine::get_accumulator_recharge_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "power/accumulator/recharge_source", PROPERTY_HINT_ENUM,
-                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
-                        "Main"),
-                "set_accumulator_recharge_source", "get_accumulator_recharge_source");
-
-        ClassDB::bind_method(
-                D_METHOD("set_power_cable_power_source"), &TrainElectricEngine::set_power_cable_power_source);
-        ClassDB::bind_method(
-                D_METHOD("get_power_cable_power_source"), &TrainElectricEngine::get_power_cable_power_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "power/power_cable/source", PROPERTY_HINT_ENUM,
-                        "NoPower,BioPower,MechPower,ElectricPower,SteamPower"
-                        "Main"),
-                "set_power_cable_power_source", "get_power_cable_power_source");
-
-        ClassDB::bind_method(
-                D_METHOD("set_power_cable_steam_pressure"), &TrainElectricEngine::set_power_cable_steam_pressure);
-        ClassDB::bind_method(
-                D_METHOD("get_power_cable_steam_pressure"), &TrainElectricEngine::get_power_cable_steam_pressure);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "power/power_cable/steam_pressure"), "set_power_cable_steam_pressure",
-                "get_power_cable_steam_pressure");
-
+        BIND_PROPERTY_W_HINT(Variant::INT, "engine_power_source", "power/source", &TrainElectricEngine::set_engine_power_source, &TrainElectricEngine::get_engine_power_source, "power_source", PROPERTY_HINT_ENUM, "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,Main");
+        BIND_PROPERTY(Variant::INT, "number_of_collectors", "power/current_collector/number_of_collectors", &TrainElectricEngine::set_collectors_no, &TrainElectricEngine::get_collectors_no, "number_of_collectors");
+        BIND_PROPERTY(Variant::FLOAT, "max_voltage", "power/current_collector/max_voltage", &TrainElectricEngine::set_max_voltage, &TrainElectricEngine::get_max_voltage, "max_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "max_current", "power/current_collector/max_current", &TrainElectricEngine::set_max_current, &TrainElectricEngine::get_max_current, "max_current");
+        BIND_PROPERTY(Variant::FLOAT, "max_collector_lifting", "power/current_collector/max_collector_lifting", &TrainElectricEngine::set_max_collector_lifting, &TrainElectricEngine::get_max_collector_lifting, "max_collector_lifting");
+        BIND_PROPERTY(Variant::FLOAT, "min_collector_lifting", "power/current_collector/min_collector_lifting", &TrainElectricEngine::set_min_collector_lifting, &TrainElectricEngine::get_min_collector_lifting, "min_collector_lifting");
+        BIND_PROPERTY(Variant::FLOAT, "collector_sliding_width", "power/current_collector/collector_sliding_width", &TrainElectricEngine::set_collector_sliding_width, &TrainElectricEngine::get_collector_sliding_width, "collector_sliding_width");
+        BIND_PROPERTY(Variant::FLOAT, "min_main_switch_voltage", "power/current_collector/min_main_switch_voltage", &TrainElectricEngine::set_min_main_switch_voltage, &TrainElectricEngine::get_min_main_switch_voltage, "min_main_switch_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "min_pantograph_tank_pressure", "power/current_collector/min_pantograph_tank_pressure", &TrainElectricEngine::set_min_pantograph_tank_pressure, &TrainElectricEngine::get_min_pantograph_tank_pressure, "min_pantograph_tank_pressure");
+        BIND_PROPERTY(Variant::FLOAT, "max_pantograph_tank_pressure", "power/current_collector/max_pantograph_tank_pressure", &TrainElectricEngine::set_max_pantograph_tank_pressure, &TrainElectricEngine::get_max_pantograph_tank_pressure, "max_pantograph_tank_pressure");
+        BIND_PROPERTY(Variant::BOOL, "overvoltage_relay", "power/current_collector/overvoltage_relay", &TrainElectricEngine::set_overvoltage_relay, &TrainElectricEngine::get_overvoltage_relay, "overvoltage_relay");
+        BIND_PROPERTY(Variant::FLOAT, "required_main_switch_voltage", "power/current_collector/required_main_switch_voltage", &TrainElectricEngine::set_required_main_switch_voltage, &TrainElectricEngine::get_required_main_switch_voltage, "required_main_switch_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "transducer_input_voltage", "power/transducer/input_voltage", &TrainElectricEngine::set_transducer_input_voltage, &TrainElectricEngine::get_transducer_input_voltage, "transducer_input_voltage");
+        BIND_PROPERTY_W_HINT(Variant::INT, "accumulator_recharge_source", "power/accumulator/recharge_source", &TrainElectricEngine::set_accumulator_recharge_source, &TrainElectricEngine::get_accumulator_recharge_source, "accumulator_recharge_source", PROPERTY_HINT_ENUM, "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,Main");
+        BIND_PROPERTY_W_HINT(Variant::INT, "power_cable_power_source", "power/power_cable/source", &TrainElectricEngine::set_power_cable_power_source, &TrainElectricEngine::get_power_cable_power_source, "power_cable_power_source", PROPERTY_HINT_ENUM, "NoPower,BioPower,MechPower,ElectricPower,SteamPower,Main");
+        BIND_PROPERTY(Variant::FLOAT, "power_cable_steam_pressure", "power/power_cable/steam_pressure", &TrainElectricEngine::set_power_cable_steam_pressure, &TrainElectricEngine::get_power_cable_steam_pressure, "power_cable_steam_pressure");
         ClassDB::bind_method(D_METHOD("compressor", "enabled"), &TrainElectricEngine::compressor);
         ClassDB::bind_method(D_METHOD("converter", "enabled"), &TrainElectricEngine::converter);
     }
 
     void TrainElectricEngine::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {
         TrainEngine::_do_fetch_state_from_mover(mover, state);
-
         state["compressor_enabled"] = mover->CompressorFlag;
         state["compressor_allowed"] = mover->CompressorAllow;
         state["converter_enabled"] = mover->ConverterFlag;
@@ -161,7 +57,7 @@ namespace godot {
         switch (power_source) {
             case TrainController::POWER_SOURCE_INTERNAL: {
                 const std::map<TrainController::TrainPowerType, TPowerType>::const_iterator lookup =
-                        _controller->power_type_map.find(power_cable_power_trans);
+                        _controller->power_type_map.find(power_cable_power_source);
                 mover->EnginePowerSource.PowerType = lookup != _controller->power_type_map.end() ? lookup->second : TPowerType::NoPower;
             }
             case TrainController::POWER_SOURCE_TRANSDUCER: {
@@ -190,7 +86,7 @@ namespace godot {
             }
             case TrainController::POWER_SOURCE_POWERCABLE: {
                 mover->EnginePowerSource.RPowerCable.PowerTrans =
-                    _controller->power_type_map.at(power_cable_power_trans);
+                    _controller->power_type_map.at(power_cable_power_source);
                 if (mover->EnginePowerSource.RPowerCable.PowerTrans == TPowerType::SteamPower) {
                     mover->EnginePowerSource.RPowerCable.SteamPressure = power_cable_steam_pressure;
                 }
@@ -233,140 +129,5 @@ namespace godot {
 
     TrainController::TrainPowerSource TrainElectricEngine::get_engine_power_source() const {
         return power_source;
-    }
-
-    void TrainElectricEngine::set_number_of_collectors(const int p_coll_no) {
-        collectors_no = p_coll_no;
-        _dirty = true;
-    }
-
-    int TrainElectricEngine::get_number_of_collectors() const {
-        return collectors_no;
-    }
-
-    void TrainElectricEngine::set_max_voltage(const float p_max_voltage) {
-        max_voltage = p_max_voltage;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_max_voltage() const {
-        return max_voltage;
-    }
-
-    void TrainElectricEngine::set_max_current(const float p_max_current) {
-        max_current = p_max_current;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_max_current() const {
-        return max_current;
-    }
-
-    void TrainElectricEngine::set_max_collector_lifting(const float p_max_collector_lifting) {
-        max_collector_lifting = p_max_collector_lifting;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_max_collector_lifting() const {
-        return max_collector_lifting;
-    }
-
-    void TrainElectricEngine::set_min_collector_lifting(const float p_min_collector_lifting) {
-        min_collector_lifting = p_min_collector_lifting;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_min_collector_lifting() const {
-        return min_collector_lifting;
-    }
-
-    void TrainElectricEngine::set_csw(const float p_csw) {
-        collector_sliding_width = p_csw;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_csw() const {
-        return collector_sliding_width;
-    }
-
-    void TrainElectricEngine::set_min_main_switch_voltage(const float p_min_main_switch_voltage) {
-        min_main_switch_voltage = p_min_main_switch_voltage;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_min_main_switch_voltage() const {
-        return min_main_switch_voltage;
-    }
-
-    void TrainElectricEngine::set_min_pantograph_tank_pressure(const float p_min_pantograph_tank_pressure) {
-        min_pantograph_tank_pressure = p_min_pantograph_tank_pressure;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_min_pantograph_tank_pressure() const {
-        return min_pantograph_tank_pressure;
-    }
-
-    void TrainElectricEngine::set_max_pantograph_tank_pressure(const float p_max_pantograph_tank_pressure) {
-        max_pantograph_tank_pressure = p_max_pantograph_tank_pressure;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_max_pantograph_tank_pressure() const {
-        return max_pantograph_tank_pressure;
-    }
-
-    void TrainElectricEngine::set_overvoltage_relay(const bool p_overvoltage_relay_value) {
-        overvoltage_relay = p_overvoltage_relay_value;
-        _dirty = true;
-    }
-
-    bool TrainElectricEngine::get_overvoltage_relay() const {
-        return overvoltage_relay;
-    }
-
-    void TrainElectricEngine::set_required_main_switch_voltage(const float p_required_main_switch_voltage) {
-        required_main_switch_voltage = p_required_main_switch_voltage;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_required_main_switch_voltage() const {
-        return required_main_switch_voltage;
-    }
-
-    void TrainElectricEngine::set_transducer_input_voltage(const float p_transducer_input_voltage) {
-        transducer_input_voltage = p_transducer_input_voltage;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_transducer_input_voltage() const {
-        return transducer_input_voltage;
-    }
-
-    void TrainElectricEngine::set_accumulator_recharge_source(const TrainController::TrainPowerSource p_source) {
-        accumulator_recharge_source = p_source;
-        _dirty = true;
-    }
-
-    TrainController::TrainPowerSource TrainElectricEngine::get_accumulator_recharge_source() const {
-        return accumulator_recharge_source;
-    }
-
-    void TrainElectricEngine::set_power_cable_power_source(const TrainController::TrainPowerType p_source) {
-        power_cable_power_trans = p_source;
-        _dirty = true;
-    }
-
-    TrainController::TrainPowerType TrainElectricEngine::get_power_cable_power_source() const {
-        return power_cable_power_trans;
-    }
-
-    void TrainElectricEngine::set_power_cable_steam_pressure(const float p_pressure) {
-        power_cable_steam_pressure = p_pressure;
-        _dirty = true;
-    }
-
-    float TrainElectricEngine::get_power_cable_steam_pressure() const {
-        return power_cable_steam_pressure;
     }
 } // namespace godot

--- a/src/engines/TrainElectricEngine.hpp
+++ b/src/engines/TrainElectricEngine.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "TrainEngine.hpp"
-
+#include "macros.hpp"
 
 namespace godot {
     class TrainController;
@@ -13,80 +13,24 @@ namespace godot {
         public:
             static void _bind_methods();
             TrainController::TrainPowerSource power_source = TrainController::POWER_SOURCE_NOT_DEFINED;
-            int collectors_no = 0;
-            float max_voltage = 0;
-            float max_current = 0;
-            /**
-             * Minimal collector lifting from the folded position, in meters.
-             */
-            float min_collector_lifting = 0;
-            /**
-             * Maximum collector lifting, in meters.
-             */
-            float max_collector_lifting = 0;
-            /**
-             * Working width of the collector/pantograph slide, in meters
-             */
-            float collector_sliding_width = 0;
-            /**
-             * The minimum closing voltage of the main switch, in volts.
-             * By default, it is 0.5*max_voltage
-             */
-            float min_main_switch_voltage = 0.5f * max_voltage;
-            /**
-             * Minimum pressure in the Pantograph Tank (PT) to raise the pantograph, in MPa
-             */
-            float min_pantograph_tank_pressure = 0;
-            /**
-             * Maximum pressure in the Pantograph Tank
-             */
-            float max_pantograph_tank_pressure = 0;
-            /**
-             * Determines if we do have an overvoltage relay on the train
-             */
-            bool overvoltage_relay = false;
-            /**
-             * The voltage required to turn on the main switch
-             * By default, it is 0.6*max_voltage
-             */
-            float required_main_switch_voltage = 0.6f * max_voltage;
-            float transducer_input_voltage = 0;
-            TrainController::TrainPowerSource accumulator_recharge_source =
-                    TrainController::TrainPowerSource::POWER_SOURCE_NOT_DEFINED;
-            TrainController::TrainPowerType power_cable_power_trans = TrainController::TrainPowerType::POWER_TYPE_NONE;
-            float power_cable_steam_pressure = 0;
+            MAKE_MEMBER_GS(int, collectors_no, 0);
+            MAKE_MEMBER_GS(float, max_voltage, 0.0);
+            MAKE_MEMBER_GS(float, max_current, 0.0);
+            MAKE_MEMBER_GS(float, min_collector_lifting, 0.0);
+            MAKE_MEMBER_GS(float, max_collector_lifting, 0.0);
+            MAKE_MEMBER_GS(float, collector_sliding_width, 0.0);
+            MAKE_MEMBER_GS(float, min_main_switch_voltage, 0.5f * max_voltage);
+            MAKE_MEMBER_GS(float, min_pantograph_tank_pressure, 0.0);
+            MAKE_MEMBER_GS(float, max_pantograph_tank_pressure, 0.0);
+            MAKE_MEMBER_GS_DIRTY(bool, overvoltage_relay, false);
+            MAKE_MEMBER_GS(float, required_main_switch_voltage, 0.6f * max_voltage);
+            MAKE_MEMBER_GS(float, transducer_input_voltage, 0.0f);
+            MAKE_MEMBER_GS_NR(TrainController::TrainPowerSource, accumulator_recharge_source, TrainController::TrainPowerSource::POWER_SOURCE_NOT_DEFINED);
+            MAKE_MEMBER_GS_NR(TrainController::TrainPowerType, power_cable_power_source, TrainController::TrainPowerType::POWER_TYPE_NONE);
+            MAKE_MEMBER_GS(float, power_cable_steam_pressure, 0.0f);
+
             void set_engine_power_source(TrainController::TrainPowerSource p_source);
             TrainController::TrainPowerSource get_engine_power_source() const;
-            int get_number_of_collectors() const;
-            void set_number_of_collectors(int p_coll_no);
-            void set_max_voltage(float p_max_voltage);
-            float get_max_voltage() const;
-            void set_max_current(float p_max_current);
-            float get_max_current() const;
-            void set_max_collector_lifting(float p_max_collector_lifting);
-            float get_max_collector_lifting() const;
-            void set_min_collector_lifting(float p_min_collector_lifting);
-            float get_min_collector_lifting() const;
-            float get_csw() const;
-            void set_min_main_switch_voltage(float p_min_main_switch_voltage);
-            float get_min_main_switch_voltage() const;
-            void set_min_pantograph_tank_pressure(float p_min_pantograph_tank_pressure);
-            float get_min_pantograph_tank_pressure() const;
-            void set_max_pantograph_tank_pressure(float p_max_pantograph_tank_pressure);
-            float get_max_pantograph_tank_pressure() const;
-            void set_overvoltage_relay(bool p_overvoltage_relay_value);
-            bool get_overvoltage_relay() const;
-            void set_required_main_switch_voltage(float p_required_main_switch_voltage);
-            float get_required_main_switch_voltage() const;
-            void set_csw(float p_csw);
-            void set_transducer_input_voltage(float p_transducer_input_voltage);
-            float get_transducer_input_voltage() const;
-            void set_accumulator_recharge_source(TrainController::TrainPowerSource p_source);
-            TrainController::TrainPowerSource get_accumulator_recharge_source() const;
-            void set_power_cable_power_source(TrainController::TrainPowerType p_source);
-            TrainController::TrainPowerType get_power_cable_power_source() const;
-            void set_power_cable_steam_pressure(float p_pressure);
-            float get_power_cable_steam_pressure() const;
             void compressor(bool p_enabled);
             void converter(bool p_enabled);
             void _register_commands() override;

--- a/src/engines/TrainElectricSeriesEngine.cpp
+++ b/src/engines/TrainElectricSeriesEngine.cpp
@@ -1,18 +1,14 @@
 #include "TrainElectricSeriesEngine.hpp"
+#include "macros.hpp"
+
 #include <godot_cpp/classes/gd_extension.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 namespace godot {
     void TrainElectricSeriesEngine::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("get_nominal_voltage"), &TrainElectricSeriesEngine::get_nominal_voltage);
-        ClassDB::bind_method(D_METHOD("set_nominal_voltage"), &TrainElectricSeriesEngine::set_nominal_voltage);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "nominal_voltage"), "set_nominal_voltage", "get_nominal_voltage");
-
-        ClassDB::bind_method(D_METHOD("get_winding_resistance"), &TrainElectricSeriesEngine::get_winding_resistance);
-        ClassDB::bind_method(D_METHOD("set_winding_resistance"), &TrainElectricSeriesEngine::set_winding_resistance);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "winding_resistance"), "set_winding_resistance", "get_winding_resistance");
+        BIND_PROPERTY(Variant::FLOAT, "nominal_voltage", "nominal_voltage", &TrainElectricSeriesEngine::set_nominal_voltage, &TrainElectricSeriesEngine::get_nominal_voltage, "nominal_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "winding_resistance", "winding_resistance", &TrainElectricSeriesEngine::set_winding_resistance, &TrainElectricSeriesEngine::get_winding_resistance, "winding_resistance");
     }
 
     TrainEngine::EngineType TrainElectricSeriesEngine::get_engine_type() {
@@ -21,27 +17,8 @@ namespace godot {
 
     void TrainElectricSeriesEngine::_do_update_internal_mover(TMoverParameters *mover) {
         TrainElectricEngine::_do_update_internal_mover(mover);
-
         mover->NominalVoltage = nominal_voltage;
         mover->WindingRes = winding_resistance;
-    }
-
-    double TrainElectricSeriesEngine::get_winding_resistance() const {
-        return winding_resistance;
-    }
-
-    void TrainElectricSeriesEngine::set_winding_resistance(const double value) {
-        winding_resistance = value;
-        _dirty = true;
-    }
-
-    double TrainElectricSeriesEngine::get_nominal_voltage() const {
-        return nominal_voltage;
-    }
-
-    void TrainElectricSeriesEngine::set_nominal_voltage(const double value) {
-        nominal_voltage = value;
-        _dirty = true;
     }
 
 } // namespace godot

--- a/src/engines/TrainElectricSeriesEngine.hpp
+++ b/src/engines/TrainElectricSeriesEngine.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "../maszyna/McZapkie/MOVER.h"
 #include "TrainElectricEngine.hpp"
-
+#include "macros.hpp"
 
 namespace godot {
     class TrainController;
@@ -10,18 +10,13 @@ namespace godot {
             GDCLASS(TrainElectricSeriesEngine, TrainElectricEngine)
         public:
             static void _bind_methods();
-            double nominal_voltage = 0.0;    // Volt -> NominalVoltage
-            double winding_resistance = 0.0; // WindingRes -> WindingRes
 
         protected:
             EngineType get_engine_type() override;
             void _do_update_internal_mover(TMoverParameters *mover) override;
 
         public:
-            double get_nominal_voltage() const;
-            void set_nominal_voltage(double value);
-
-            double get_winding_resistance() const;
-            void set_winding_resistance(double value);
+            MAKE_MEMBER_GS(double, nominal_voltage, 0.0);
+            MAKE_MEMBER_GS(double, winding_resistance, 0.0);
     };
 } // namespace godot

--- a/src/engines/TrainEngine.cpp
+++ b/src/engines/TrainEngine.cpp
@@ -1,17 +1,13 @@
 #include "TrainEngine.hpp"
+#include "macros.hpp"
+
 #include <godot_cpp/variant/utility_functions.hpp>
 
 namespace godot {
     class TrainController;
     void TrainEngine::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_motor_param_table"), &TrainEngine::set_motor_param_table);
-        ClassDB::bind_method(D_METHOD("get_motor_param_table"), &TrainEngine::get_motor_param_table);
         ClassDB::bind_method(D_METHOD("main_switch", "enabled"), &TrainEngine::main_switch);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::ARRAY, "motor_param_table", PROPERTY_HINT_TYPE_STRING, String::num(Variant::OBJECT) + "/" + String::num(PROPERTY_HINT_RESOURCE_TYPE) + ":MotorParameter", PROPERTY_USAGE_DEFAULT,
-                        "TypedArray<MotorParameter>"),
-                "set_motor_param_table", "get_motor_param_table");
+        BIND_PROPERTY_W_HINT_RES_ARRAY(Variant::ARRAY, "motor_param_table", "motor_param_table", &TrainEngine::set_motor_param_table, &TrainEngine::get_motor_param_table, "motor_param_table", PROPERTY_HINT_TYPE_STRING, "MotorParameter");
         ADD_SIGNAL(MethodInfo("engine_start"));
         ADD_SIGNAL(MethodInfo("engine_stop"));
 
@@ -47,12 +43,12 @@ namespace godot {
                 return;
             }
 
-            mover->MotorParam[i].mIsat = row->mIsat;
-            mover->MotorParam[i].fi = row->fi;
-            mover->MotorParam[i].mfi = row->mfi;
-            mover->MotorParam[i].Isat = row->Isat;
-            mover->MPTRelay[i].Iup = row->shunting_up;//bocznikowanie
-            mover->MPTRelay[i].Idown = row->shunting_down;//bocznikowanie;
+            mover->MotorParam[i].mIsat = row->get_saturation_current_multiplier();
+            mover->MotorParam[i].fi = row->get_voltage_constant();
+            mover->MotorParam[i].mfi = row->get_voltage_constant_multiplier();
+            mover->MotorParam[i].Isat = row->get_saturation_current();
+            mover->MPTRelay[i].Iup = row->get_shunting_up();//bocznikowanie
+            mover->MPTRelay[i].Idown = row->get_shunting_down();//bocznikowanie;
         }
     }
 
@@ -88,15 +84,6 @@ namespace godot {
 
     void TrainEngine::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) {
         config["main_controller_position_max"] = mover->MainCtrlPosNo;
-    }
-
-    TypedArray<MotorParameter> TrainEngine::get_motor_param_table() {
-        return motor_param_table;
-    }
-
-    void TrainEngine::set_motor_param_table(const TypedArray<MotorParameter> &p_motor_param_table) {
-        motor_param_table.clear();
-        motor_param_table.append_array(p_motor_param_table);
     }
 
     void TrainEngine::main_switch(const bool p_enabled) {

--- a/src/engines/TrainEngine.hpp
+++ b/src/engines/TrainEngine.hpp
@@ -33,8 +33,16 @@ namespace godot {
                     {MAIN, TEngineType::Main}
             };
 
-            TypedArray<MotorParameter> get_motor_param_table();
-            void set_motor_param_table(const TypedArray<MotorParameter> &p_motor_param_table);
+
+            TypedArray<MotorParameter> get_motor_param_table() {
+                return motor_param_table;
+            }
+
+            void set_motor_param_table(const TypedArray<MotorParameter> &p_motor_param_table) {
+                motor_param_table.clear();
+                motor_param_table.append_array(p_motor_param_table);
+            }
+
             void main_switch(bool p_enabled);
             static void _bind_methods();
             TypedArray<MotorParameter> motor_param_table;

--- a/src/lighting/TrainLighting.cpp
+++ b/src/lighting/TrainLighting.cpp
@@ -1,107 +1,24 @@
 #include "TrainLighting.hpp"
-
 namespace godot {
     const char *TrainLighting::SELECTOR_POSITION_CHANGED_SIGNAL = "selector_position_changed";
 
-    void TrainLighting::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_head_light_color", "color"), &TrainLighting::set_head_light_color);
-        ClassDB::bind_method(D_METHOD("get_head_light_color"), &TrainLighting::get_head_light_color);
-        ADD_PROPERTY(PropertyInfo(Variant::COLOR, "head_light/color"), "set_head_light_color", "get_head_light_color");
-        ClassDB::bind_method(D_METHOD("set_head_light_dimming_multiplier", "multiplier"), &TrainLighting::set_dimming_multiplier);
-        ClassDB::bind_method(D_METHOD("get_head_light_dimming_multiplier"), &TrainLighting::get_dimming_multiplier);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/dimming_multiplier"), "set_head_light_dimming_multiplier", "get_head_light_dimming_multiplier");
-        ClassDB::bind_method(D_METHOD("set_head_light_normal_multiplier", "multiplier"), &TrainLighting::set_normal_multiplier);
-        ClassDB::bind_method(D_METHOD("get_head_light_normal_multiplier"), &TrainLighting::get_normal_multiplier);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/normal_multiplier"), "set_head_light_normal_multiplier", "get_head_light_normal_multiplier");
-        ClassDB::bind_method(D_METHOD("set_high_beam_dimmed_multiplier", "multiplier"), &TrainLighting::set_high_beam_dimmed_multiplier);
-        ClassDB::bind_method(D_METHOD("get_high_beam_dimmed_multiplier"), &TrainLighting::get_high_beam_dimmed_multiplier);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/high_beam/dimming_multiplier"), "set_high_beam_dimmed_multiplier", "get_high_beam_dimmed_multiplier");
-        ClassDB::bind_method(D_METHOD("set_high_beam_multiplier", "multiplier"), &TrainLighting::set_high_beam_multiplier);
-        ClassDB::bind_method(D_METHOD("get_high_beam_multiplier"), &TrainLighting::get_high_beam_multiplier);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "head_light/high_beam/normal_multiplier"), "set_high_beam_multiplier", "get_high_beam_multiplier");
-        ClassDB::bind_method(
-                D_METHOD("set_lights_selector_default_position", "position"), &TrainLighting::set_default_selector_position);
-        ClassDB::bind_method(D_METHOD("get_lights_selector_default_position"), &TrainLighting::get_default_selector_position);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "lights/selector_default_position"),
-                "set_lights_selector_default_position", "get_lights_selector_default_position");
-        ClassDB::bind_method(D_METHOD("set_light_selector_position", "light_selector_position"), &TrainLighting::set_selector_position);
-        ClassDB::bind_method(D_METHOD("get_light_selector_position"), &TrainLighting::get_selector_position);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::INT, "lights/selector_position"),
-                "set_light_selector_position", "get_light_selector_position");
-        ClassDB::bind_method(
-                D_METHOD("set_wrap_light_selector", "wrap"), &TrainLighting::set_wrap_light_selector);
-        ClassDB::bind_method(D_METHOD("get_wrap_light_selector"), &TrainLighting::get_wrap_light_selector);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "lights/wrap_selector"),
-                "set_wrap_light_selector", "get_wrap_light_selector");
-        ClassDB::bind_method(D_METHOD("set_light_position_list", "light_position_list"), &TrainLighting::set_light_position_list);
-        ClassDB::bind_method(D_METHOD("get_light_position_list"), &TrainLighting::get_light_position_list);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::ARRAY, "lights/list", PROPERTY_HINT_TYPE_STRING, String::num(Variant::OBJECT) + "/" + String::num(PROPERTY_HINT_RESOURCE_TYPE) + ":LightListItem", PROPERTY_USAGE_DEFAULT, "TypedArray<LightListItem>"),
-                "set_light_position_list", "get_light_position_list");
-
-        ClassDB::bind_method(D_METHOD("set_light_source", "light_source"), &TrainLighting::set_light_source);
-        ClassDB::bind_method(D_METHOD("get_light_source"), &TrainLighting::get_light_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "light/source", PROPERTY_HINT_ENUM,
-                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
-                        "Main"),
-                "set_light_source", "get_light_source");
-        ClassDB::bind_method(
-                D_METHOD("set_generator_engine", "generator_engine"), &TrainLighting::set_generator_engine);
-        ClassDB::bind_method(D_METHOD("get_generator_engine"), &TrainLighting::get_generator_engine);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "source/generator/engine", PROPERTY_HINT_ENUM,
-                        "None,Dumb,WheelsDriven,ElectricSeriesMotor,ElectricInductionMotor,DieselEngine,SteamEngine,"
-                        "DieselElectric,Main"),
-                "set_generator_engine", "get_generator_engine");
-        ClassDB::bind_method(
-                D_METHOD("set_max_accumulator_voltage", "max_accumulator_voltage"),
-                &TrainLighting::set_max_accumulator_voltage);
-        ClassDB::bind_method(D_METHOD("get_max_accumulator_voltage"), &TrainLighting::get_max_accumulator_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "source/accumulator/max_voltage"), "set_max_accumulator_voltage",
-                "get_max_accumulator_voltage");
-        ClassDB::bind_method(
-                D_METHOD("set_alternative_light_source", "light_source"),
-                &TrainLighting::set_alternative_light_source);
-        ClassDB::bind_method(D_METHOD("get_alternative_light_source"), &TrainLighting::get_alternative_light_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "light/alternative/source", PROPERTY_HINT_ENUM,
-                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
-                        "Main"),
-                "set_alternative_light_source", "get_alternative_light_source");
-        ClassDB::bind_method(
-                D_METHOD("set_alternative_max_voltage", "alternative_max_voltage"),
-                &TrainLighting::set_alternative_max_voltage);
-        ClassDB::bind_method(D_METHOD("get_alternative_max_voltage"), &TrainLighting::get_alternative_max_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "light/alternative/max_voltage"), "set_alternative_max_voltage",
-                "get_alternative_max_voltage");
-        ClassDB::bind_method(
-                D_METHOD("set_alternative_light_capacity", "light_source"),
-                &TrainLighting::set_alternative_light_capacity);
-        ClassDB::bind_method(
-                D_METHOD("get_alternative_light_capacity"), &TrainLighting::get_alternative_light_capacity);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "light/alternative/capacity"), "set_alternative_light_capacity",
-                "get_alternative_light_capacity");
-        ClassDB::bind_method(
-                D_METHOD("set_accumulator_recharge_source", "recharge_source"),
-                &TrainLighting::set_accumulator_recharge_source);
-        ClassDB::bind_method(
-                D_METHOD("get_accumulator_recharge_source"), &TrainLighting::get_accumulator_recharge_source);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "source/accumulator/recharge_source", PROPERTY_HINT_ENUM,
-                        "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,"
-                        "Main"),
-                "set_accumulator_recharge_source", "get_accumulator_recharge_source");
+    void TrainLighting::_bind_methods() {BIND_PROPERTY(Variant::COLOR, "head_light_color", "head_light/color", &TrainLighting::set_head_light_color, &TrainLighting::get_head_light_color, "color");
+    BIND_PROPERTY(Variant::FLOAT, "head_light_dimmed_multiplier", "head_light/dimmed_multiplier", &TrainLighting::set_dimming_multiplier, &TrainLighting::get_dimming_multiplier, "multiplier");
+    BIND_PROPERTY(Variant::FLOAT, "head_light_normal_multiplier", "head_light/normal_multiplier", &TrainLighting::set_normal_multiplier, &TrainLighting::get_normal_multiplier, "multiplier");
+    BIND_PROPERTY(Variant::FLOAT, "high_beam_dimmed_multiplier", "head_light/high_beam/dimmed_multiplier", &TrainLighting::set_high_beam_dimmed_multiplier, &TrainLighting::get_high_beam_dimmed_multiplier, "multiplier");
+    BIND_PROPERTY(Variant::FLOAT, "high_beam_normal_multiplier", "head_light/high_beam/normal_multiplier", &TrainLighting::set_high_beam_multiplier, &TrainLighting::get_high_beam_multiplier, "multiplier");
+    BIND_PROPERTY(Variant::INT, "lights_default_selector_position", "lights/default_selector_position", &TrainLighting::set_default_selector_position, &TrainLighting::get_default_selector_position, "default_selector_position");
+    BIND_PROPERTY(Variant::INT, "lights_selector_position", "lights/selector_position", &TrainLighting::set_selector_position, &TrainLighting::get_selector_position, "selector_position");
+    BIND_PROPERTY(Variant::BOOL, "wrap_light_selector", "lights/wrap_selector", &TrainLighting::set_wrap_light_selector, &TrainLighting::get_wrap_light_selector, "wrap_selector");
+    BIND_PROPERTY_W_HINT_RES_ARRAY(Variant::ARRAY, "light_position_list", "lights/list", &TrainLighting::set_light_position_list, &TrainLighting::get_light_position_list, "light_position_list", PROPERTY_HINT_TYPE_STRING, "LighListItem");
+    BIND_PROPERTY_W_HINT(Variant::INT, "light_source", "light/source", &TrainLighting::set_light_source, &TrainLighting::get_light_source, "source", PROPERTY_HINT_ENUM, "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,Main");
+    BIND_PROPERTY_W_HINT(Variant::INT, "generator_engine", "source/generator/engine", &TrainLighting::set_generator_engine, &TrainLighting::get_generator_engine, "generator_engine", PROPERTY_HINT_ENUM, "None,Dumb,WheelsDriven,ElectricSeriesMotor,ElectricInductionMotor,DieselEngine,SteamEngine,DieselElectric,Main");
+    BIND_PROPERTY(Variant::FLOAT, "max_accumulator_voltage", "source/accumulator/max_voltage", &TrainLighting::set_max_accumulator_voltage, &TrainLighting::get_max_accumulator_voltage, "max_voltage");
+    BIND_PROPERTY_W_HINT(Variant::INT, "alternative_light_source", "light/alternative/source", &TrainLighting::set_alternative_light_source, &TrainLighting::get_alternative_light_source, "source", PROPERTY_HINT_ENUM, "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,Main");
+    BIND_PROPERTY(Variant::FLOAT, "alternative_max_voltage", "light/alternative/max_voltage", &TrainLighting::set_alternative_max_voltage, &TrainLighting::get_alternative_max_voltage, "max_voltage");
+    BIND_PROPERTY(Variant::FLOAT, "alternative_light_capacity", "light/alternative/capacity", &TrainLighting::set_alternative_light_capacity, &TrainLighting::get_alternative_light_capacity, "capacity");
+    BIND_PROPERTY_W_HINT(Variant::INT, "accumulator_recharge_source", "source/accumulator/recharge_source", &TrainLighting::set_accumulator_recharge_source, &TrainLighting::get_accumulator_recharge_source, "recharge_source", PROPERTY_HINT_ENUM, "NotDefined,InternalSource,Transducer,Generator,Accumulator,CurrentCollector,PowerCable,Heater,Main");
+    BIND_PROPERTY(Variant::INT, "instrument_type", "instrument_type", &TrainLighting::set_instrument_light_type, &TrainLighting::get_instrument_light_type, "instrument_type");
         ClassDB::bind_method(D_METHOD("increase_light_selector_position"), &TrainLighting::increase_light_selector_position);
         ClassDB::bind_method(D_METHOD("decrease_light_selector_position"), &TrainLighting::decrease_light_selector_position);
         ADD_SIGNAL(MethodInfo(SELECTOR_POSITION_CHANGED_SIGNAL, PropertyInfo(Variant::INT, "position")));
@@ -140,153 +57,6 @@ namespace godot {
         unregister_command("increase_light_selector_position", Callable(this, "increase_light_selector_position"));
         unregister_command("decrease_light_selector_position", Callable(this, "decrease_light_selector_position"));
         TrainPart::_unregister_commands();
-    }
-
-    void TrainLighting::set_light_source(const TrainController::TrainPowerSource p_light_source) {
-        light_source = p_light_source;
-        _dirty = true;
-    }
-
-    TrainController::TrainPowerSource TrainLighting::get_light_source() const {
-        return light_source;
-    }
-
-    void TrainLighting::set_generator_engine(const TrainEngine::EngineType p_generator_engine) {
-        generator_engine = p_generator_engine;
-        _dirty = true;
-    }
-
-    TrainEngine::EngineType TrainLighting::get_generator_engine() const {
-        return generator_engine;
-    }
-
-    void TrainLighting::set_max_accumulator_voltage(const double p_max_accumulator_voltage) {
-        max_accumulator_voltage = p_max_accumulator_voltage;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_max_accumulator_voltage() const {
-        return max_accumulator_voltage;
-    }
-
-    void TrainLighting::set_alternative_light_source(const TrainController::TrainPowerSource p_light_source) {
-        alternative_light_source = p_light_source;
-        _dirty = true;
-    }
-
-    TrainController::TrainPowerSource TrainLighting::get_alternative_light_source() const {
-        return alternative_light_source;
-    }
-
-    void TrainLighting::set_alternative_max_voltage(const double p_max_accumulator_voltage) {
-        max_accumulator_voltage = p_max_accumulator_voltage;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_alternative_max_voltage() const {
-        return alternative_max_voltage;
-    }
-
-    void TrainLighting::set_alternative_light_capacity(const double p_max_accumulator_voltage) {
-        max_accumulator_voltage = p_max_accumulator_voltage;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_alternative_light_capacity() const {
-        return alternative_max_voltage;
-    }
-
-    void TrainLighting::set_accumulator_recharge_source(
-            const TrainController::TrainPowerSource p_accumulator_recharge_source) {
-        accumulator_recharge_source = p_accumulator_recharge_source;
-        _dirty = true;
-    }
-
-    TrainController::TrainPowerSource TrainLighting::get_accumulator_recharge_source() const {
-        return accumulator_recharge_source;
-    }
-
-    void TrainLighting::set_light_position_list(const TypedArray<LightListItem> &p_light_position_list) {
-        light_position_list.clear();
-        light_position_list.append_array(p_light_position_list);
-        _dirty = true;
-    }
-
-    TypedArray<LightListItem> TrainLighting::get_light_position_list() const {
-        return light_position_list;
-    }
-
-    void TrainLighting::set_wrap_light_selector(const bool p_wrap_light_selector) {
-        wrap_light_selector = p_wrap_light_selector;
-        _dirty = true;
-    }
-
-    bool TrainLighting::get_wrap_light_selector() const {
-        return wrap_light_selector;
-    }
-
-    void TrainLighting::set_default_selector_position(const int p_selector_position) {
-        default_selector_position = p_selector_position;
-        _dirty = true;
-    }
-
-    int TrainLighting::get_default_selector_position() const {
-        return default_selector_position;
-    }
-
-    void TrainLighting::set_selector_position(const int p_selector_position) {
-        selector_position = p_selector_position;
-        emit_signal(SELECTOR_POSITION_CHANGED_SIGNAL, p_selector_position);
-        _dirty = true;
-    }
-
-    int TrainLighting::get_selector_position() const {
-        return selector_position;
-    }
-
-    void TrainLighting::set_head_light_color(const Color p_head_light_color) {
-        head_light_color = p_head_light_color;
-        _dirty = true;
-    }
-
-    Color TrainLighting::get_head_light_color() const {
-        return head_light_color;
-    }
-
-    void TrainLighting::set_dimming_multiplier(const double p_dimming_multiplier) {
-        dimming_multiplier = p_dimming_multiplier;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_dimming_multiplier() const {
-        return dimming_multiplier;
-    }
-
-    void TrainLighting::set_normal_multiplier(const double p_normal_multiplier) {
-        normal_multiplier = p_normal_multiplier;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_normal_multiplier() const {
-        return normal_multiplier;
-    }
-
-    void TrainLighting::set_high_beam_dimmed_multiplier(const double p_high_beam_dimmed_multiplier) {
-        high_beam_dimmed_multiplier = p_high_beam_dimmed_multiplier;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_high_beam_dimmed_multiplier() const {
-        return high_beam_dimmed_multiplier;
-    }
-
-    void TrainLighting::set_high_beam_multiplier(const double p_high_beam_multiplier) {
-        high_beam_multiplier = p_high_beam_multiplier;
-        _dirty = true;
-    }
-
-    double TrainLighting::get_high_beam_multiplier() const {
-        return high_beam_multiplier;
     }
 
     void TrainLighting::increase_light_selector_position() {

--- a/src/lighting/TrainLighting.hpp
+++ b/src/lighting/TrainLighting.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../core/TrainPart.hpp"
 #include "../engines/TrainElectricEngine.hpp"
+#include "macros.hpp"
 #include "resources/lighting/LightListItem.hpp"
 #include <godot_cpp/classes/node.hpp>
 
@@ -12,6 +13,7 @@ namespace godot {
         private:
             static void _bind_methods();
             const TrainController *_controller = memnew(TrainController);
+            TypedArray<LightListItem> light_position_list;
         protected:
             void _do_update_internal_mover(TMoverParameters *mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
@@ -20,96 +22,31 @@ namespace godot {
             void _unregister_commands() override;
         public:
             static const char* SELECTOR_POSITION_CHANGED_SIGNAL;
+            MAKE_MEMBER_GS_DIRTY(int, selector_position, 0);
+            MAKE_MEMBER_GS(bool, wrap_light_selector, false);
+            MAKE_MEMBER_GS(int, default_selector_position, 0);
+            MAKE_MEMBER_GS_NR(TrainController::TrainPowerSource, light_source, TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR);
+            MAKE_MEMBER_GS_NR(TrainEngine::EngineType, generator_engine, TrainEngine::EngineType::MAIN);
+            MAKE_MEMBER_GS(double, max_accumulator_voltage, 0.0);
+            MAKE_MEMBER_GS_NR(TrainController::TrainPowerSource, alternative_light_source, TrainController::TrainPowerSource::POWER_SOURCE_ACCUMULATOR);
+            MAKE_MEMBER_GS(double, alternative_max_voltage, 24.0);
+            MAKE_MEMBER_GS(double, alternative_light_capacity, 495.0);
+            MAKE_MEMBER_GS_NR(TrainController::TrainPowerSource, accumulator_recharge_source, TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR);
+            MAKE_MEMBER_GS(Color, head_light_color, Color(255, 255, 255));
+            MAKE_MEMBER_GS(double, dimming_multiplier, 0.6);
+            MAKE_MEMBER_GS(double, normal_multiplier, 1.0);
+            MAKE_MEMBER_GS(double, high_beam_dimmed_multiplier, 2.5);
+            MAKE_MEMBER_GS(double, high_beam_multiplier, 2.8);
+            MAKE_MEMBER_GS(int, instrument_light_type, 0);
+            TypedArray<LightListItem> get_light_position_list() {
+                return light_position_list;
+            };
 
-            TypedArray<LightListItem> light_position_list;
-
-            int selector_position = 0;
-
-            /**
-             * Whether a selector can turn in 360 deg or not
-             */
-            bool wrap_light_selector = false;
-
-            /**
-             * Default position of the light selector
-             */
-            int default_selector_position = 0;
-
-            /**
-             * Generator for light power. Default value taken from internal mover
-             */
-            TrainController::TrainPowerSource light_source = TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR;
-
-            /**
-             * Engine type of the generator
-             */
-            TrainEngine::EngineType generator_engine = TrainEngine::EngineType::MAIN;
-
-            /**
-             * Accumulator capacity for an alternative light source. Default value from internal mover
-             */
-            double max_accumulator_voltage = 0.0;
-
-            /**
-             * Alternative generator for light power. Default value taken from internal mover
-             */
-            TrainController::TrainPowerSource alternative_light_source = TrainController::TrainPowerSource::POWER_SOURCE_ACCUMULATOR;
-
-            /**
-             * Accumulator capacity for an alternative light power source. Default value from internal mover
-             */
-            double alternative_max_voltage = 24.0;
-
-            /**
-             * Accumulator capacity for an alternative light power source. Default value from internal mover
-             */
-            double alternative_light_capacity = 495.0;
-
-            /**
-             * Accumulator recharge source for an alternative light power source. Default value from internal mover
-             */
-            TrainController::TrainPowerSource accumulator_recharge_source = TrainController::TrainPowerSource::POWER_SOURCE_GENERATOR;
-
-            Color head_light_color = Color(255, 255, 255);
-            double dimming_multiplier = 0.6;
-            double normal_multiplier = 1.0;
-            double high_beam_dimmed_multiplier = 2.5;
-            double high_beam_multiplier = 2.8;
-            int instrument_light_type = 0; // ABu 030405 - swiecenie uzaleznione od: 0-nic, 1-obw.gl, 2-przetw., 3-rozrzad, 4-external lights
-            void set_light_source(TrainController::TrainPowerSource p_light_source);
-            TrainController::TrainPowerSource get_light_source() const;
-            void set_generator_engine(TrainEngine::EngineType p_generator_engine);
-            TrainEngine::EngineType get_generator_engine() const;
-            void set_max_accumulator_voltage(double p_max_accumulator_voltage);
-            double get_max_accumulator_voltage() const;
-            void set_alternative_light_source(TrainController::TrainPowerSource p_light_source);
-            TrainController::TrainPowerSource get_alternative_light_source() const;
-            void set_alternative_max_voltage(double p_max_accumulator_voltage);
-            double get_alternative_max_voltage() const;
-            void set_alternative_light_capacity(double p_max_accumulator_voltage);
-            double get_alternative_light_capacity() const;
-            void set_accumulator_recharge_source(TrainController::TrainPowerSource p_accumulator_recharge_source);
-            TrainController::TrainPowerSource get_accumulator_recharge_source() const;
-            void set_light_position_list(const TypedArray<LightListItem> &p_light_position_list);
-            TypedArray<LightListItem> get_light_position_list() const;
-            void set_wrap_light_selector(bool p_wrap_light_selector);
-            bool get_wrap_light_selector() const;
-            void set_default_selector_position(int p_selector_position);
-            int get_default_selector_position() const;
-            void set_selector_position(int p_selector_position);
-            int get_selector_position() const;
-            void set_head_light_color(Color p_head_light_color);
-            Color get_head_light_color() const;
-            void set_dimming_multiplier(double p_dimming_multiplier);
-            double get_dimming_multiplier() const;
-            void set_normal_multiplier(double p_normal_multiplier);
-            double get_normal_multiplier() const;
-            void set_high_beam_dimmed_multiplier(double p_high_beam_dimmed_multiplier);
-            double get_high_beam_dimmed_multiplier() const;
-            void set_high_beam_multiplier(double p_high_beam_multiplier);
-            double get_high_beam_multiplier() const;
+            void set_light_position_list(const TypedArray<LightListItem> &p_list) {
+                light_position_list.clear();
+                light_position_list.append_array(p_list);
+            };
             void increase_light_selector_position();
             void decrease_light_selector_position();
-
     };
 } // namespace godot

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -1,0 +1,149 @@
+#ifndef MACROS_HPP
+#define MACROS_HPP
+
+/**
+ * Macro for generating private members with their setters and getters
+ * @param type Member type
+ * @param name Member name
+ * @param default_value Default value
+ */
+#define MAKE_MEMBER_GS(type, name, default_value)                                                                      \
+private:                                                                                                               \
+    type name = default_value;                                                                                         \
+                                                                                                                       \
+public:                                                                                                                \
+    const type &get_##name() const {                                                                                   \
+        return name;                                                                                                   \
+    }                                                                                                                  \
+    void set_##name(const type &value) {                                                                               \
+        name = value;                                                                                                  \
+    }
+
+/**
+ * Macro for generating private synchronized members with their setters and getters. Those members will ALWAYS be
+ * synchronized with internal mover
+ * @param type Member type
+ * @param name Member name
+ * @param default_value Default value
+ */
+#define MAKE_MEMBER_GS_DIRTY(type, name, default_value)                                                                \
+private:                                                                                                               \
+    type name = default_value;                                                                                         \
+                                                                                                                       \
+public:                                                                                                                \
+    const type &get_##name() const {                                                                                   \
+        return name;                                                                                                   \
+    }                                                                                                                  \
+    void set_##name(const type &value) {                                                                               \
+        name = value;                                                                                                  \
+        _dirty = true;                                                                                                 \
+    }
+
+/**
+ * Macro for generating private members with their setters and getters without a const reference
+ * @param type Member type
+ * @param name Member name
+ * @param default_value Default value
+ */
+#define MAKE_MEMBER_GS_NR(type, name, default_value)                                                                   \
+private:                                                                                                               \
+    type name = default_value;                                                                                         \
+                                                                                                                       \
+public:                                                                                                                \
+    type get_##name() const {                                                                                    \
+        return name;                                                                                                   \
+    }                                                                                                                  \
+    void set_##name(type value) {                                                                                      \
+        name = value;                                                                                                  \
+    }
+
+
+/**
+ * Generates Godot setters and getters with the desired property using the following:
+ * @param p_type Property type
+ * @param p_name Property full name, used to generate setter and getter method names
+ * @param p_path Property path in the inspector
+ * @param m_setter Setter reference
+ * @param m_getter Getter reference
+ * @param p_setter_arg Argument name for setter
+ * <example>
+ * BIND_PROPERTY(Variant::FLOAT, "ca_max_hold_time", "ca_max_hold_time", &TrainSecuritySystem::SetCAMaxHoldTime,
+ * &TrainSecuritySystem::GetCAMaxHoldTime, "delay");
+ * </example>
+ */
+#define BIND_PROPERTY(p_type, p_name, p_path, m_setter, m_getter, p_setter_arg)                                        \
+    ClassDB::bind_method(D_METHOD("set_" + String(p_name), p_setter_arg), m_setter);                                   \
+    ClassDB::bind_method(D_METHOD("get_" + String(p_name)), m_getter);                                                 \
+    ADD_PROPERTY(PropertyInfo(p_type, String(p_path)), "set_" + String(p_name), "get_" + String(p_name));
+
+/**
+ * Generates Godot setters and getters with the desired property using the following:
+ * @param p_name Property full name, used to generate setter and getter method names
+ * @param p_path Property path in the inspector
+ * @param m_setter Setter reference
+ * @param m_getter Getter reference
+ * @param p_setter_arg Argument name for setter
+ * <example>
+ * BIND_PROPERTY(Variant::FLOAT, "ca_max_hold_time", "ca_max_hold_time", &TrainSecuritySystem::SetCAMaxHoldTime,
+ * &TrainSecuritySystem::GetCAMaxHoldTime, "delay");
+ * </example>
+ */
+#define BIND_PROPERTY_ARRAY(p_name, p_path, m_setter, m_getter, p_setter_arg)                                          \
+    ClassDB::bind_method(D_METHOD("set_" + String(p_name), p_setter_arg), m_setter);                                   \
+    ClassDB::bind_method(D_METHOD("get_" + String(p_name)), m_getter);                                                 \
+    ADD_PROPERTY(                                                                                                      \
+            PropertyInfo(Variant::ARRAY, String(p_path), PROPERTY_HINT_ARRAY_TYPE), "set_" + String(p_name),           \
+            "get_" + String(p_name));
+
+/**
+ * Generates Godot setters and getters with the desired property using the following with a hint:
+ * @param p_type Property type (Variant type)
+ * @param p_name Property full name, used to generate setter and getter method names
+ * @param p_path Property path in the inspector
+ * @param m_setter Setter reference
+ * @param m_getter Getter reference
+ * @param p_setter_arg Argument name for setter
+ * @param p_hint_type Property hint type
+ * @param p_hint_string Property hint string
+ * <example>
+ * BIND_PROPERTY_W_HINT(Variant::INT, "selector_position", "selector_position",
+ * &TrainLighting::SetSelectorPosition, &TrainLighting::GetSelectorPosition, "position",
+ * PROPERTY_HINT_RANGE, "0,4,1");
+ * </example>
+ */
+#define BIND_PROPERTY_W_HINT(p_type, p_name, p_path, m_setter, m_getter, p_setter_arg, p_hint_type, p_hint_string)     \
+    ClassDB::bind_method(D_METHOD("set_" + String(p_name), p_setter_arg), m_setter);                                   \
+    ClassDB::bind_method(D_METHOD("get_" + String(p_name)), m_getter);                                                 \
+    ADD_PROPERTY(                                                                                                      \
+            PropertyInfo(p_type, String(p_path), p_hint_type, String(p_hint_string)), "set_" + String(p_name),         \
+            "get_" + String(p_name));
+
+/**
+ * Generates Godot setters and getters for resource array properties:
+ * @param p_type Property type (Variant type)
+ * @param p_name Property full name, used to generate setter and getter method names
+ * @param p_path Property path in the inspector
+ * @param m_setter Setter reference
+ * @param m_getter Getter reference
+ * @param p_setter_arg Argument name for setter
+ * @param p_hint_type Property hint type
+ * @param p_hint_resource_name Resource type name
+ * <example>
+ * BIND_PROPERTY_W_HINT_RES_ARRAY(Variant::ARRAY, "lights", "lights",
+ * &TrainLighting::SetLightPositionList, &TrainLighting::GetLightPositionList, "list",
+ * PROPERTY_HINT_ARRAY_TYPE, "LightListItem");
+ * </example>
+ */
+#define BIND_PROPERTY_W_HINT_RES_ARRAY(                                                                                \
+        p_type, p_name, p_path, m_setter, m_getter, p_setter_arg, p_hint_type, p_hint_resource_name)                   \
+    ClassDB::bind_method(D_METHOD("set_" + String(p_name), p_setter_arg), m_setter);                                   \
+    ClassDB::bind_method(D_METHOD("get_" + String(p_name)), m_getter);                                                 \
+    ADD_PROPERTY(                                                                                                      \
+            PropertyInfo(                                                                                              \
+                    p_type, String(p_path), p_hint_type,                                                               \
+                    String::num(Variant::OBJECT) + "/" + String::num(PROPERTY_HINT_RESOURCE_TYPE) + ":" +              \
+                            String(p_hint_resource_name),                                                              \
+                    PROPERTY_USAGE_DEFAULT, "TypedArray<" + String(p_hint_resource_name) + ">"),                       \
+            "set_" + String(p_name), "get_" + String(p_name));
+
+#endif // MACROS_HPP

--- a/src/resources/engines/MotorParameter.cpp
+++ b/src/resources/engines/MotorParameter.cpp
@@ -1,113 +1,16 @@
 #include "MotorParameter.hpp"
+#include "macros.hpp"
 
 namespace godot {
     void MotorParameter::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_shunting_up", "shunting_up"), &MotorParameter::set_shunting_up);
-        ClassDB::bind_method(D_METHOD("get_shunting_up"), &MotorParameter::get_shunting_up);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shunting_up"), "set_shunting_up", "get_shunting_up");
-
-        ClassDB::bind_method(D_METHOD("set_shunting_down", "shunting_down"), &MotorParameter::set_shunting_down);
-        ClassDB::bind_method(D_METHOD("get_shunting_down"), &MotorParameter::get_shunting_down);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shunting_down"), "set_shunting_down", "get_shunting_down");
-
-        ClassDB::bind_method(D_METHOD("set_mfi", "mfi"), &MotorParameter::set_mfi);
-        ClassDB::bind_method(D_METHOD("get_mfi"), &MotorParameter::get_mfi);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mfi"), "set_mfi", "get_mfi");
-
-        ClassDB::bind_method(D_METHOD("set_mIsat", "mIsat"), &MotorParameter::set_mIsat);
-        ClassDB::bind_method(D_METHOD("get_mIsat"), &MotorParameter::get_mIsat);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mIsat"), "set_mIsat", "get_mIsat");
-
-        ClassDB::bind_method(D_METHOD("set_mfi0", "mfi0"), &MotorParameter::set_mfi0);
-        ClassDB::bind_method(D_METHOD("get_mfi0"), &MotorParameter::get_mfi0);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mfi0"), "set_mfi0", "get_mfi0");
-
-        ClassDB::bind_method(D_METHOD("set_fi", "fi"), &MotorParameter::set_fi);
-        ClassDB::bind_method(D_METHOD("get_fi"), &MotorParameter::get_fi);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fi"), "set_fi", "get_fi");
-
-        ClassDB::bind_method(D_METHOD("set_Isat", "Isat"), &MotorParameter::set_Isat);
-        ClassDB::bind_method(D_METHOD("get_Isat"), &MotorParameter::get_Isat);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "Isat"), "set_Isat", "get_Isat");
-
-        ClassDB::bind_method(D_METHOD("set_fi0", "fi0"), &MotorParameter::set_fi0);
-        ClassDB::bind_method(D_METHOD("get_fi0"), &MotorParameter::get_fi0);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fi0"), "set_fi0", "get_fi0");
-
-        ClassDB::bind_method(D_METHOD("set_auto_switch", "auto_switch"), &MotorParameter::set_auto_switch);
-        ClassDB::bind_method(D_METHOD("get_auto_switch"), &MotorParameter::get_auto_switch);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_switch"), "set_auto_switch", "get_auto_switch");
-    }
-
-    void MotorParameter::set_shunting_up(const double p_shunting_up) {
-        shunting_up = p_shunting_up;
-    }
-
-    void MotorParameter::set_shunting_down(const double p_shunting_down) {
-        shunting_down = p_shunting_down;
-    }
-
-    void MotorParameter::set_mfi(const double p_mfi) {
-        mfi = p_mfi;
-    }
-
-    void MotorParameter::set_mIsat(const double p_mIsat) {
-        mIsat = p_mIsat;
-    }
-
-    void MotorParameter::set_mfi0(const double p_mfi0) {
-        mfi0 = p_mfi0;
-    }
-
-    void MotorParameter::set_fi(const double p_fi) {
-        fi = p_fi;
-    }
-
-    void MotorParameter::set_Isat(const double p_Isat) {
-        Isat = p_Isat;
-    }
-
-    void MotorParameter::set_fi0(const double p_fi0) {
-        fi0 = p_fi0;
-    }
-
-    void MotorParameter::set_auto_switch(const bool p_auto_switch) {
-        auto_switch = p_auto_switch;
-    }
-
-    double MotorParameter::get_shunting_up() const {
-        return shunting_up;
-    }
-
-    double MotorParameter::get_shunting_down() const {
-        return shunting_down;
-    }
-
-    double MotorParameter::get_mfi() const {
-        return mfi;
-    }
-
-    double MotorParameter::get_mIsat() const {
-        return mIsat;
-    }
-
-    double MotorParameter::get_mfi0() const {
-        return mfi0;
-    }
-
-    double MotorParameter::get_fi() const {
-        return fi;
-    }
-
-    double MotorParameter::get_Isat() const {
-        return Isat;
-    }
-
-    double MotorParameter::get_fi0() const {
-        return fi0;
-    }
-
-    bool MotorParameter::get_auto_switch() const {
-        return auto_switch;
+        BIND_PROPERTY(Variant::FLOAT, "shunting_up", "shunting_up", &MotorParameter::set_shunting_up, &MotorParameter::get_shunting_up, "shunting_up");
+        BIND_PROPERTY(Variant::FLOAT, "shunting_down", "shunting_down", &MotorParameter::set_shunting_down, &MotorParameter::get_shunting_down, "shunting_down");
+        BIND_PROPERTY(Variant::FLOAT, "voltage_constant_multiplier", "voltage_constant_multiplier", &MotorParameter::set_voltage_constant_multiplier, &MotorParameter::get_voltage_constant_multiplier, "voltage_constant_multiplier");
+        BIND_PROPERTY(Variant::FLOAT, "saturation_current_multiplier", "saturation_current_multiplier", &MotorParameter::set_saturation_current_multiplier, &MotorParameter::get_saturation_current_multiplier, "saturation_current_multiplier");
+        BIND_PROPERTY(Variant::FLOAT, "initial_voltage_constant_multiplier", "initial_voltage_constant_multiplier", &MotorParameter::set_initial_voltage_constant_multiplier, &MotorParameter::get_initial_voltage_constant_multiplier, "initial_voltage_constant_multiplier");
+        BIND_PROPERTY(Variant::FLOAT, "voltage_constant", "voltage_constant", &MotorParameter::set_voltage_constant, &MotorParameter::get_voltage_constant, "voltage_constant");
+        BIND_PROPERTY(Variant::FLOAT, "saturation_current", "saturation_current", &MotorParameter::set_saturation_current, &MotorParameter::get_saturation_current, "saturation_current");
+        BIND_PROPERTY(Variant::FLOAT, "initial_voltage_constant", "initial_voltage_constant", &MotorParameter::set_initial_voltage_constant, &MotorParameter::get_initial_voltage_constant, "initial_voltage_constant");
+        BIND_PROPERTY(Variant::BOOL, "auto_switch", "auto_switch", &MotorParameter::set_auto_switch, &MotorParameter::get_auto_switch, "auto_switch");
     }
 } // namespace godot

--- a/src/resources/engines/MotorParameter.hpp
+++ b/src/resources/engines/MotorParameter.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "macros.hpp"
 #include <godot_cpp/classes/resource.hpp>
 
 namespace godot {
@@ -7,34 +8,14 @@ namespace godot {
 
         public:
             static void _bind_methods();
-
-            double shunting_up = 0.0;
-            double shunting_down = 0.0;
-            double mfi = 0.0;
-            double mIsat = 0.0;
-            double mfi0 = 0.0; // aproksymacja M(I) silnika} {dla dizla mIsat=przekladnia biegu
-            double fi = 0.0;
-            double Isat = 0.0;
-            double fi0 = 0.0; // aproksymacja E(n)=fi*n}    {dla dizla fi, mfi: predkosci przelozenia biegu <->
-            bool auto_switch = false;
-
-            void set_shunting_up(double p_shunting_up);
-            void set_shunting_down(double p_shunting_down);
-            void set_mfi(double p_mfi);
-            void set_mIsat(double p_mIsat);
-            void set_mfi0(double p_mfi0);
-            void set_fi(double p_fi);
-            void set_Isat(double p_Isat);
-            void set_fi0(double p_fi0);
-            void set_auto_switch(bool p_auto_switch);
-            double get_shunting_up() const;
-            double get_shunting_down() const;
-            double get_mfi() const;
-            double get_mIsat() const;
-            double get_mfi0() const;
-            double get_fi() const;
-            double get_Isat() const;
-            double get_fi0() const;
-            bool get_auto_switch() const;
+            MAKE_MEMBER_GS(double, shunting_up, 0.0);
+            MAKE_MEMBER_GS(double, shunting_down, 0.0);
+            MAKE_MEMBER_GS(double, voltage_constant_multiplier, 0.0);
+            MAKE_MEMBER_GS(double, saturation_current_multiplier, 0.0);
+            MAKE_MEMBER_GS(double, initial_voltage_constant_multiplier, 0.0);
+            MAKE_MEMBER_GS(double, voltage_constant, 0.0);
+            MAKE_MEMBER_GS(double, saturation_current, 0.0);
+            MAKE_MEMBER_GS(double, initial_voltage_constant, 0.0);
+            MAKE_MEMBER_GS(bool, auto_switch, 0.0);
     };
 } // namespace godot

--- a/src/resources/engines/WWListItem.cpp
+++ b/src/resources/engines/WWListItem.cpp
@@ -2,104 +2,13 @@
 
 namespace godot {
     void WWListItem::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("set_rpm", "rpm"), &WWListItem::set_rpm);
-        ClassDB::bind_method(D_METHOD("get_rpm"), &WWListItem::get_rpm);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rpm"), "set_rpm", "get_rpm");
-
-        ClassDB::bind_method(D_METHOD("set_max_power", "max_power"), &WWListItem::set_max_power);
-        ClassDB::bind_method(D_METHOD("get_max_power"), &WWListItem::get_max_power);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_power"), "set_max_power", "get_max_power");
-
-        ClassDB::bind_method(D_METHOD("set_max_voltage", "max_voltage"), &WWListItem::set_max_voltage);
-        ClassDB::bind_method(D_METHOD("get_max_voltage"), &WWListItem::get_max_voltage);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_voltage"), "set_max_voltage", "get_max_voltage");
-
-        ClassDB::bind_method(D_METHOD("set_max_current", "max_current"), &WWListItem::set_max_current);
-        ClassDB::bind_method(D_METHOD("get_max_current"), &WWListItem::get_max_current);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_current"), "set_max_current", "get_max_current");
-
-        ClassDB::bind_method(D_METHOD("set_shunting", "shunting_mode"), &WWListItem::set_shunting);
-        ClassDB::bind_method(D_METHOD("get_shunting"), &WWListItem::get_shunting);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "has_shunting"), "set_shunting", "get_shunting");
-
-        ClassDB::bind_method(
-                D_METHOD("set_min_wakeup_voltage", "min_wakeup_voltage"), &WWListItem::set_min_wakeup_voltage);
-        ClassDB::bind_method(D_METHOD("get_min_wakeup_voltage"), &WWListItem::get_min_wakeup_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "min_wakeup_voltage"), "set_min_wakeup_voltage", "get_min_wakeup_voltage");
-
-        ClassDB::bind_method(
-                D_METHOD("set_max_wakeup_voltage", "max_wakeup_voltage"), &WWListItem::set_max_wakeup_voltage);
-        ClassDB::bind_method(D_METHOD("get_max_wakeup_voltage"), &WWListItem::get_max_wakeup_voltage);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "max_wakeup_voltage"), "set_max_wakeup_voltage", "get_max_wakeup_voltage");
-
-        ClassDB::bind_method(D_METHOD("set_max_wakeup_power", "max_wakeup_power"), &WWListItem::set_max_wakeup_power);
-        ClassDB::bind_method(D_METHOD("get_max_wakeup_power"), &WWListItem::get_max_wakeup_power);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_wakeup_power"), "set_max_wakeup_power", "get_max_wakeup_power");
-    }
-
-    void WWListItem::set_rpm(const double p_rpm) {
-        rpm = p_rpm;
-    }
-
-    double WWListItem::get_rpm() const {
-        return rpm;
-    }
-
-    void WWListItem::set_max_power(const double p_max_power) {
-        max_power = p_max_power;
-    }
-
-    double WWListItem::get_max_power() const {
-        return max_power;
-    }
-
-    void WWListItem::set_max_voltage(const double p_max_voltage) {
-        max_voltage = p_max_voltage;
-    }
-
-    double WWListItem::get_max_voltage() const {
-        return max_voltage;
-    }
-
-    void WWListItem::set_max_current(const double p_max_current) {
-        max_current = p_max_current;
-    }
-
-    double WWListItem::get_max_current() const {
-        return max_current;
-    }
-
-    void WWListItem::set_shunting(const bool p_shunting) {
-        has_shunting = p_shunting;
-    }
-
-    bool WWListItem::get_shunting() const {
-        return has_shunting;
-    }
-
-    void WWListItem::set_min_wakeup_voltage(const double p_min_wakeup_voltage) {
-        min_wakeup_voltage = p_min_wakeup_voltage;
-    }
-
-    double WWListItem::get_min_wakeup_voltage() const {
-        return min_wakeup_voltage;
-    }
-
-    void WWListItem::set_max_wakeup_voltage(const double p_max_wakeup_voltage) {
-        max_wakeup_voltage = p_max_wakeup_voltage;
-    }
-
-    double WWListItem::get_max_wakeup_voltage() const {
-        return max_wakeup_voltage;
-    }
-
-    void WWListItem::set_max_wakeup_power(const double p_max_wakeup_power) {
-        max_wakeup_power = p_max_wakeup_power;
-    }
-
-    double WWListItem::get_max_wakeup_power() const {
-        return max_wakeup_power;
+        BIND_PROPERTY(Variant::FLOAT, "rpm", "rpm", &WWListItem::set_rpm, &WWListItem::get_rpm, "rpm");
+        BIND_PROPERTY(Variant::FLOAT, "max_power", "max_power", &WWListItem::set_max_power, &WWListItem::get_max_power, "max_power");
+        BIND_PROPERTY(Variant::FLOAT, "max_voltage", "max_voltage", &WWListItem::set_max_voltage, &WWListItem::get_max_voltage, "max_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "max_current", "max_current", &WWListItem::set_max_current, &WWListItem::get_max_current, "max_current");
+        BIND_PROPERTY(Variant::BOOL, "shunting", "has_shunting", &WWListItem::set_has_shunting, &WWListItem::get_has_shunting, "has_shunting");
+        BIND_PROPERTY(Variant::FLOAT, "min_wakeup_voltage", "min_wakeup_voltage", &WWListItem::set_min_wakeup_voltage, &WWListItem::get_min_wakeup_voltage, "min_wakeup_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "max_wakeup_voltage", "max_wakeup_voltage", &WWListItem::set_max_wakeup_voltage, &WWListItem::get_max_wakeup_voltage, "max_wakeup_voltage");
+        BIND_PROPERTY(Variant::FLOAT, "max_wakeup_power", "max_wakeup_power", &WWListItem::set_max_wakeup_power, &WWListItem::get_max_wakeup_power, "max_wakeup_power");
     }
 } // namespace godot

--- a/src/resources/engines/WWListItem.hpp
+++ b/src/resources/engines/WWListItem.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "macros.hpp"
 #include <godot_cpp/classes/resource.hpp>
 
 namespace godot {
@@ -7,47 +8,13 @@ namespace godot {
 
         public:
             static void _bind_methods();
-
-            double rpm = 0.0;
-            double max_power = 0.0;
-            double max_voltage = 0.0;
-            double max_current = 0.0;
-
-            /**
-             * has shunting controller?
-             */
-            bool has_shunting = false;
-
-            /**
-             * voltage with minimal wake-up
-             */
-            double min_wakeup_voltage = 0.0;
-
-            /**
-             * voltage with maximum wake-up
-             */
-            double max_wakeup_voltage = 0.0;
-
-            /**
-             * power with maximum wake-up
-             */
-            double max_wakeup_power = 0.0;
-
-            void set_rpm(double p_rpm);
-            double get_rpm() const;
-            void set_max_power(double p_max_power);
-            double get_max_power() const;
-            void set_max_voltage(double p_max_voltage);
-            double get_max_voltage() const;
-            void set_max_current(double p_max_current);
-            double get_max_current() const;
-            void set_shunting(bool p_shunting);
-            bool get_shunting() const;
-            void set_min_wakeup_voltage(double p_min_wakeup_voltage);
-            double get_min_wakeup_voltage() const;
-            void set_max_wakeup_voltage(double p_max_wakeup_voltage);
-            double get_max_wakeup_voltage() const;
-            void set_max_wakeup_power(double p_max_wakeup_power);
-            double get_max_wakeup_power() const;
+            MAKE_MEMBER_GS(double, rpm, 0.0);
+            MAKE_MEMBER_GS(double, max_power, 0.0);
+            MAKE_MEMBER_GS(double, max_voltage, 0.0);
+            MAKE_MEMBER_GS(double, max_current, 0.0);
+            MAKE_MEMBER_GS(bool, has_shunting, 0.0);
+            MAKE_MEMBER_GS(double, min_wakeup_voltage, 0.0);
+            MAKE_MEMBER_GS(double, max_wakeup_voltage, 0.0);
+            MAKE_MEMBER_GS(double, max_wakeup_power, 0.0);
     };
 } // namespace godot

--- a/src/resources/lighting/LightListItem.cpp
+++ b/src/resources/lighting/LightListItem.cpp
@@ -1,138 +1,17 @@
 #include "LightListItem.hpp"
-
+#include "macros.hpp"
 namespace godot {
-    void LightListItem::_bind_methods() {
-        //Cabin A
-        ClassDB::bind_method(D_METHOD("set_cabin_a_head_light", "head_light"), &LightListItem::set_cabin_a_head_light);
-        ClassDB::bind_method(D_METHOD("get_cabin_a_head_light"), &LightListItem::get_cabin_a_head_light);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/head_light"), "set_cabin_a_head_light", "get_cabin_a_head_light");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_a_left_white_signal", "left_white_signal"), &LightListItem::set_cabin_a_left_white_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_a_left_white_signal"), &LightListItem::get_cabin_a_left_white_signal);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "cabin_a/left/white_signal"), "set_cabin_a_left_white_signal", "get_cabin_a_left_white_signal");
-
-        ClassDB::bind_method(D_METHOD("set_cabin_a_left_red_signal", "left_red_signal"), &LightListItem::set_cabin_a_left_red_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_a_left_red_signal"), &LightListItem::get_cabin_a_left_red_signal);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/left/red_signal"), "set_cabin_a_left_red_signal", "get_cabin_a_left_red_signal");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_a_right_white_signal", "right_white_light"), &LightListItem::set_cabin_a_right_white_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_a_right_white_signal"), &LightListItem::get_cabin_a_right_white_signal);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "cabin_a/right/white_signal"), "set_cabin_a_right_white_signal", "get_cabin_a_right_white_signal");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_a_right_red_signal", "right_red_signal"), &LightListItem::set_cabin_a_right_red_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_a_right_red_signal"), &LightListItem::get_cabin_a_right_red_signal);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_a/right/red_signal"), "set_cabin_a_right_red_signal", "get_cabin_a_right_red_signal");
-
+    void LightListItem::_bind_methods() {//Cabin A
+        BIND_PROPERTY(Variant::BOOL, "cabin_a_head_light", "cabin_a/head_light", &LightListItem::set_cab_a_head_light, &LightListItem::get_cab_a_head_light, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_a_left_white_signal", "cabin_a/left/white_signal", &LightListItem::set_cab_a_left_white_signal, &LightListItem::get_cab_a_left_white_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_a_left_red_signal", "cabin_a/left/red_signal", &LightListItem::set_cab_a_left_red_signal, &LightListItem::get_cab_a_left_red_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_a_right_white_signal", "cabin_a/right/white_signal", &LightListItem::set_cab_a_left_white_signal, &LightListItem::get_cab_a_left_white_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_a_right_red_signal", "cabin_a/right/red_signal", &LightListItem::set_cab_a_right_red_signal, &LightListItem::get_cab_a_right_red_signal, "enabled");
         //Cabin B
-
-        ClassDB::bind_method(D_METHOD("set_cabin_b_head_light", "head_light"), &LightListItem::set_cabin_b_head_light);
-        ClassDB::bind_method(D_METHOD("get_cabin_b_head_light"), &LightListItem::get_cabin_b_head_light);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/head_light"), "set_cabin_b_head_light", "get_cabin_b_head_light");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_b_left_white_signal", "left_white_signal"), &LightListItem::set_cabin_b_left_white_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_b_left_white_signal"), &LightListItem::get_cabin_b_left_white_signal);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "cabin_b/left/white_signal"), "set_cabin_b_left_white_signal", "get_cabin_b_left_white_signal");
-
-        ClassDB::bind_method(D_METHOD("set_cabin_b_left_red_signal", "left_red_signal"), &LightListItem::set_cabin_b_left_red_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_b_left_red_signal"), &LightListItem::get_cabin_b_left_red_signal);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/left/red_signal"), "set_cabin_b_left_red_signal", "get_cabin_b_left_red_signal");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_b_right_white_signal", "left_right_light"), &LightListItem::set_cabin_b_right_white_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_b_right_white_signal"), &LightListItem::get_cabin_b_right_white_signal);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "cabin_b/right/white_signal"), "set_cabin_b_right_white_signal", "get_cabin_b_right_white_signal");
-
-        ClassDB::bind_method(
-                D_METHOD("set_cabin_b_right_red_signal", "right_red_signal"), &LightListItem::set_cabin_b_right_red_signal);
-        ClassDB::bind_method(D_METHOD("get_cabin_b_right_red_signal"), &LightListItem::get_cabin_b_right_red_signal);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cabin_b/right/red_signal"), "set_cabin_b_right_red_signal", "get_cabin_b_right_red_signal");
-    }
-
-    void LightListItem::set_cabin_a_head_light(const bool p_head_light) {
-        cabin_a.head_light = p_head_light;
-    }
-
-    bool LightListItem::get_cabin_a_head_light() const {
-        return cabin_a.head_light;
-    }
-
-    void LightListItem::set_cabin_a_left_white_signal(const bool p_left_white_signal) {
-        cabin_a.left_white_signal = p_left_white_signal;
-    }
-
-    bool LightListItem::get_cabin_a_left_white_signal() const {
-        return cabin_a.left_white_signal;
-    }
-
-    void LightListItem::set_cabin_a_left_red_signal(const bool p_left_red_signal) {
-        cabin_a.left_red_signal = p_left_red_signal;
-    }
-
-    bool LightListItem::get_cabin_a_left_red_signal() const {
-        return cabin_a.left_red_signal;
-    }
-
-    void LightListItem::set_cabin_a_right_white_signal(const bool p_right_white_signal) {
-        cabin_a.right_white_signal = p_right_white_signal;
-    }
-
-    bool LightListItem::get_cabin_a_right_white_signal() const {
-        return cabin_a.right_white_signal;
-    }
-
-    void LightListItem::set_cabin_a_right_red_signal(const bool p_right_red_signal) {
-        cabin_a.right_red_signal = p_right_red_signal;
-    }
-
-    bool LightListItem::get_cabin_a_right_red_signal() const {
-        return cabin_a.right_red_signal;
-    }
-
-    void LightListItem::set_cabin_b_head_light(const bool p_head_light) {
-        cabin_b.head_light = p_head_light;
-    }
-
-    bool LightListItem::get_cabin_b_head_light() const {
-        return cabin_b.head_light;
-    }
-
-    void LightListItem::set_cabin_b_left_white_signal(const bool p_left_white_signal) {
-        cabin_b.left_white_signal = p_left_white_signal;
-    }
-
-    bool LightListItem::get_cabin_b_left_white_signal() const {
-        return cabin_b.left_white_signal;
-    }
-
-    void LightListItem::set_cabin_b_left_red_signal(const bool p_left_red_signal) {
-        cabin_b.left_red_signal = p_left_red_signal;
-    }
-
-    bool LightListItem::get_cabin_b_left_red_signal() const {
-        return cabin_b.left_red_signal;
-    }
-
-    void LightListItem::set_cabin_b_right_white_signal(const bool p_right_white_signal) {
-        cabin_b.right_white_signal = p_right_white_signal;
-    }
-
-    bool LightListItem::get_cabin_b_right_white_signal() const {
-        return cabin_b.right_white_signal;
-    }
-
-    void LightListItem::set_cabin_b_right_red_signal(const bool p_right_red_signal) {
-        cabin_b.right_red_signal = p_right_red_signal;
-    }
-
-    bool LightListItem::get_cabin_b_right_red_signal() const {
-        return cabin_b.right_red_signal;
+        BIND_PROPERTY(Variant::BOOL, "cabin_b_head_light", "cabin_b/head_light", &LightListItem::set_cab_b_head_light, &LightListItem::get_cab_b_head_light, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_b_left_white_signal", "cabin_b/left/white_signal", &LightListItem::set_cab_b_left_white_signal, &LightListItem::get_cab_b_left_white_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_b_left_red_signal", "cabin_b/left/red_signal", &LightListItem::set_cab_b_left_red_signal, &LightListItem::get_cab_b_left_red_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_b_right_white_signal", "cabin_b/right/white_signal", &LightListItem::set_cab_b_right_white_signal, &LightListItem::get_cab_b_right_white_signal, "enabled");
+        BIND_PROPERTY(Variant::BOOL, "cabin_b_right_red_signal", "cabin_b/right/red_signal", &LightListItem::set_cab_b_right_red_signal, &LightListItem::get_cab_b_right_red_signal, "enabled");
     }
 } // namespace godot

--- a/src/resources/lighting/LightListItem.hpp
+++ b/src/resources/lighting/LightListItem.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "macros.hpp"
 #include <godot_cpp/classes/resource.hpp>
 
 namespace godot {
@@ -7,34 +8,15 @@ namespace godot {
 
         public:
             static void _bind_methods();
-            void set_cabin_a_head_light(bool p_head_light);
-            bool get_cabin_a_head_light() const;
-            void set_cabin_a_left_white_signal(bool p_left_white_signal);
-            bool get_cabin_a_left_white_signal() const;
-            void set_cabin_a_left_red_signal(bool p_left_red_signal);
-            bool get_cabin_a_left_red_signal() const;
-            void set_cabin_a_right_white_signal(bool p_right_white_signal);
-            bool get_cabin_a_right_white_signal() const;
-            void set_cabin_a_right_red_signal(bool p_right_red_signal);
-            bool get_cabin_a_right_red_signal() const;
-            void set_cabin_b_head_light(bool p_head_light);
-            bool get_cabin_b_head_light() const;
-            void set_cabin_b_left_white_signal(bool p_left_white_signal);
-            bool get_cabin_b_left_white_signal() const;
-            void set_cabin_b_left_red_signal(bool p_left_red_signal);
-            bool get_cabin_b_left_red_signal() const;
-            void set_cabin_b_right_white_signal(bool p_right_white_signal);
-            bool get_cabin_b_right_white_signal() const;
-            void set_cabin_b_right_red_signal(bool p_right_red_signal);
-            bool get_cabin_b_right_red_signal() const;
-
-            struct CabinLights {
-                bool head_light = false;
-                bool left_white_signal = false;
-                bool left_red_signal = false;
-                bool right_white_signal = false;
-                bool right_red_signal = false;
-            } cabin_a, cabin_b;
-
+            MAKE_MEMBER_GS(bool, cab_a_head_light, false);
+            MAKE_MEMBER_GS(bool, cab_a_left_white_signal, false);
+            MAKE_MEMBER_GS(bool, cab_a_left_red_signal, false);
+            MAKE_MEMBER_GS(bool, cab_a_right_white_signal, false);
+            MAKE_MEMBER_GS(bool, cab_a_right_red_signal, false);
+            MAKE_MEMBER_GS(bool, cab_b_head_light, false);
+            MAKE_MEMBER_GS(bool, cab_b_left_white_signal, false);
+            MAKE_MEMBER_GS(bool, cab_b_left_red_signal, false);
+            MAKE_MEMBER_GS(bool, cab_b_right_white_signal, false);
+            MAKE_MEMBER_GS(bool, cab_b_right_red_signal, false);
     };
 } // namespace godot

--- a/src/systems/TrainSecuritySystem.cpp
+++ b/src/systems/TrainSecuritySystem.cpp
@@ -1,165 +1,30 @@
 #include "TrainSecuritySystem.hpp"
+#include "macros.hpp"
+
 #include <godot_cpp/classes/gd_extension.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 namespace godot {
     void TrainSecuritySystem::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("get_aware_system_active"), &TrainSecuritySystem::get_aware_system_active);
-        ClassDB::bind_method(D_METHOD("set_aware_system_active"), &TrainSecuritySystem::set_aware_system_active);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "aware_system/active"), "set_aware_system_active",
-                "get_aware_system_active");
-
-        ClassDB::bind_method(D_METHOD("get_aware_system_cabsignal"), &TrainSecuritySystem::get_aware_system_cabsignal);
-        ClassDB::bind_method(D_METHOD("set_aware_system_cabsignal"), &TrainSecuritySystem::set_aware_system_cabsignal);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "aware_system/cabsignal"), "set_aware_system_cabsignal",
-                "get_aware_system_cabsignal");
-
-        ClassDB::bind_method(
-                D_METHOD("get_aware_system_separate_acknowledge"),
-                &TrainSecuritySystem::get_aware_system_separate_acknowledge);
-        ClassDB::bind_method(
-                D_METHOD("set_aware_system_separate_acknowledge"),
-                &TrainSecuritySystem::set_aware_system_separate_acknowledge);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "aware_system/separate_acknowledge"),
-                "set_aware_system_separate_acknowledge", "get_aware_system_separate_acknowledge");
-
-        ClassDB::bind_method(D_METHOD("get_aware_system_sifa"), &TrainSecuritySystem::get_aware_system_sifa);
-        ClassDB::bind_method(D_METHOD("set_aware_system_sifa"), &TrainSecuritySystem::set_aware_system_sifa);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::BOOL, "aware_system/sifa"), "set_aware_system_sifa", "get_aware_system_sifa");
-
-        ClassDB::bind_method(D_METHOD("get_aware_delay"), &TrainSecuritySystem::get_aware_delay);
-        ClassDB::bind_method(D_METHOD("set_aware_delay"), &TrainSecuritySystem::set_aware_delay);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "aware_delay"), "set_aware_delay", "get_aware_delay");
-
-        ClassDB::bind_method(D_METHOD("get_emergency_brake_delay"), &TrainSecuritySystem::get_emergency_brake_delay);
-        ClassDB::bind_method(D_METHOD("set_emergency_brake_delay"), &TrainSecuritySystem::set_emergency_brake_delay);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "emergency_brake_delay"), "set_emergency_brake_delay",
-                "get_emergency_brake_delay");
-
-        ClassDB::bind_method(
-                D_METHOD("get_emergency_brake_warning_signal"),
-                &TrainSecuritySystem::get_emergency_brake_warning_signal);
-        ClassDB::bind_method(
-                D_METHOD("set_emergency_brake_warning_signal"),
-                &TrainSecuritySystem::set_emergency_brake_warning_signal);
-        ADD_PROPERTY(
-                PropertyInfo(
-                        Variant::INT, "emergency_brake_warning_signal", PROPERTY_HINT_ENUM,
-                        "SIREN_LOW_TONE,SIREN_HIGH_TONE,WHISTLE"),
-                "set_emergency_brake_warning_signal", "get_emergency_brake_warning_signal");
-
-        ClassDB::bind_method(D_METHOD("get_radio_stop"), &TrainSecuritySystem::get_radio_stop);
-        ClassDB::bind_method(D_METHOD("set_radio_stop"), &TrainSecuritySystem::set_radio_stop);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "radio_stop"), "set_radio_stop", "get_radio_stop");
-
-        ClassDB::bind_method(D_METHOD("get_sound_signal_delay"), &TrainSecuritySystem::get_sound_signal_delay);
-        ClassDB::bind_method(D_METHOD("set_sound_signal_delay", "value"), &TrainSecuritySystem::set_sound_signal_delay);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "sound_signal_delay"), "set_sound_signal_delay", "get_sound_signal_delay");
-
-        ClassDB::bind_method(D_METHOD("get_shp_magnet_distance"), &TrainSecuritySystem::get_shp_magnet_distance);
-        ClassDB::bind_method(D_METHOD("set_shp_magnet_distance"), &TrainSecuritySystem::set_shp_magnet_distance);
-        ADD_PROPERTY(
-                PropertyInfo(Variant::FLOAT, "shp_magnet_distance"), "set_shp_magnet_distance",
-                "get_shp_magnet_distance");
-
-        ClassDB::bind_method(D_METHOD("get_ca_max_hold_time"), &TrainSecuritySystem::get_ca_max_hold_time);
-        ClassDB::bind_method(D_METHOD("set_ca_max_hold_time"), &TrainSecuritySystem::set_ca_max_hold_time);
-        ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ca_max_hold_time"), "set_ca_max_hold_time", "get_ca_max_hold_time");
+        BIND_PROPERTY(Variant::BOOL, "aware_system_active", "aware_system/active", &TrainSecuritySystem::set_aware_system_active, &TrainSecuritySystem::get_aware_system_active, "state");
+        BIND_PROPERTY(Variant::BOOL, "aware_system_cabsignal", "aware_system/cabsignal", &TrainSecuritySystem::set_aware_system_cab_signal, &TrainSecuritySystem::get_aware_system_cab_signal, "state");
+        BIND_PROPERTY(Variant::BOOL, "aware_system_separate_acknowledge", "aware_system/separate_acknowledge", &TrainSecuritySystem::set_aware_system_separate_acknowledge, &TrainSecuritySystem::get_aware_system_separate_acknowledge, "state");
+        BIND_PROPERTY(Variant::BOOL, "aware_system_sifa", "aware_system/sifa", &TrainSecuritySystem::set_aware_system_sifa, &TrainSecuritySystem::get_aware_system_sifa, "state");
+        BIND_PROPERTY(Variant::FLOAT, "aware_delay", "aware_delay", &TrainSecuritySystem::set_aware_delay, &TrainSecuritySystem::get_aware_delay, "delay");
+        BIND_PROPERTY(Variant::FLOAT, "emergency_brake_delay", "emergency_brake/delay", &TrainSecuritySystem::set_emergency_brake_delay, &TrainSecuritySystem::get_emergency_brake_delay, "delay");
+        BIND_PROPERTY_W_HINT(Variant::INT, "emergency_brake_warning_signal", "emergency_brake/warning_signal", &TrainSecuritySystem::set_brake_warning_signal, &TrainSecuritySystem::get_brake_warning_signal, "signal", PROPERTY_HINT_ENUM, "SIREN_LOW_TONE,SIREN_HIGH_TONE,WHISTLE");
+        BIND_PROPERTY(Variant::BOOL, "radio_stop_enabled", "radio_stop/enabled", &TrainSecuritySystem::set_radio_stop_enabled, &TrainSecuritySystem::get_radio_stop_enabled, "state");
+        BIND_PROPERTY(Variant::FLOAT, "sound_signal_delay", "sound_signal_delay", &TrainSecuritySystem::set_sound_signal_delay, &TrainSecuritySystem::get_sound_signal_delay, "delay");
+        BIND_PROPERTY(Variant::FLOAT, "shp_magnet_distance", "shp_magnet_distance", &TrainSecuritySystem::set_shp_magnet_distance, &TrainSecuritySystem::get_shp_magnet_distance, "distance");
+        BIND_PROPERTY(Variant::FLOAT, "ca_max_hold_time", "ca_max_hold_time", &TrainSecuritySystem::set_ca_max_hold_time, &TrainSecuritySystem::get_ca_max_hold_time, "delay");
         ClassDB::bind_method(D_METHOD("security_acknowledge", "enabled"), &TrainSecuritySystem::security_acknowledge);
-
         ADD_SIGNAL(MethodInfo("blinking_changed", PropertyInfo(Variant::BOOL, "state")));
         ADD_SIGNAL(MethodInfo("beeping_changed", PropertyInfo(Variant::BOOL, "state")));
 
         BIND_ENUM_CONSTANT(BRAKE_WARNINGSIGNAL_SIREN_LOWTONE);
         BIND_ENUM_CONSTANT(BRAKE_WARNINGSIGNAL_SIREN_HIGHTONE);
         BIND_ENUM_CONSTANT(BRAKE_WARNINGSIGNAL_WHISTLE);
-    }
-    // Getters
-    bool TrainSecuritySystem::get_aware_system_active() const {
-        return aware_system_active;
-    }
-    bool TrainSecuritySystem::get_aware_system_cabsignal() const {
-        return aware_system_cabsignal;
-    }
-    bool TrainSecuritySystem::get_aware_system_separate_acknowledge() const {
-        return aware_system_separate_acknowledge;
-    }
-    bool TrainSecuritySystem::get_aware_system_sifa() const {
-        return aware_system_sifa;
-    }
-    double TrainSecuritySystem::get_aware_delay() const {
-        return aware_delay;
-    }
-    double TrainSecuritySystem::get_emergency_brake_delay() const {
-        return emergency_brake_delay;
-    }
-    TrainSecuritySystem::EmergencyBrakeWarningSignal TrainSecuritySystem::get_emergency_brake_warning_signal() const {
-        return emergency_brake_warning_signal;
-    }
-    bool TrainSecuritySystem::get_radio_stop() const {
-        return radio_stop;
-    }
-    double TrainSecuritySystem::get_sound_signal_delay() const {
-        return sound_signal_delay;
-    }
-    double TrainSecuritySystem::get_shp_magnet_distance() const {
-        return shp_magnet_distance;
-    }
-    double TrainSecuritySystem::get_ca_max_hold_time() const {
-        return ca_max_hold_time;
-    }
-
-    // Setters
-    void TrainSecuritySystem::set_aware_system_active(const bool p_state) {
-        aware_system_active = p_state;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_aware_system_cabsignal(const bool p_state) {
-        aware_system_cabsignal = p_state;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_aware_system_separate_acknowledge(const bool p_state) {
-        aware_system_separate_acknowledge = p_state;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_aware_system_sifa(const bool p_state) {
-        aware_system_sifa = p_state;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_aware_delay(const double value) {
-        aware_delay = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_emergency_brake_delay(const double value) {
-        emergency_brake_delay = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_emergency_brake_warning_signal(const EmergencyBrakeWarningSignal value) {
-        emergency_brake_warning_signal = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_radio_stop(const bool value) {
-        radio_stop = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_sound_signal_delay(const double value) {
-        sound_signal_delay = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_shp_magnet_distance(const double value) {
-        shp_magnet_distance = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_ca_max_hold_time(const double value) {
-        ca_max_hold_time = value;
-        _dirty = true;
     }
 
     void TrainSecuritySystem::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {
@@ -187,18 +52,18 @@ namespace godot {
         mover->SecuritySystem.set_enabled(enabled);
 
         mover->SecuritySystem.vigilance_enabled = aware_system_active;
-        mover->SecuritySystem.cabsignal_enabled = aware_system_cabsignal;
+        mover->SecuritySystem.cabsignal_enabled = aware_system_cab_signal;
         mover->SecuritySystem.separate_acknowledge = aware_system_separate_acknowledge;
         mover->SecuritySystem.is_sifa = aware_system_sifa;
 
         mover->SecuritySystem.AwareDelay = aware_delay;
         mover->SecuritySystem.EmergencyBrakeDelay = emergency_brake_delay;
-        mover->SecuritySystem.radiostop_enabled = radio_stop;
+        mover->SecuritySystem.radiostop_enabled = radio_stop_enabled;
         mover->SecuritySystem.SoundSignalDelay = sound_signal_delay;
         mover->SecuritySystem.MagnetLocation = shp_magnet_distance;
         mover->SecuritySystem.MaxHoldTime = ca_max_hold_time;
 
-        switch (emergency_brake_warning_signal) {
+        switch (brake_warning_signal) {
             case BRAKE_WARNINGSIGNAL_SIREN_LOWTONE:
                 mover->EmergencyBrakeWarningSignal = 1;
                 break;

--- a/src/systems/TrainSecuritySystem.hpp
+++ b/src/systems/TrainSecuritySystem.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include "../core/TrainPart.hpp"
 #include "../maszyna/McZapkie/MOVER.h"
+#include "macros.hpp"
 #include <godot_cpp/classes/node.hpp>
 
 namespace godot {
     class TrainSecuritySystem : public TrainPart {
             GDCLASS(TrainSecuritySystem, TrainPart)
-
+        private:
             static void _bind_methods();
             friend class TSecuritySystem;
 
@@ -23,50 +24,19 @@ namespace godot {
                 BRAKE_WARNINGSIGNAL_WHISTLE
             };
 
-        private:
-            bool aware_system_active = false;
-            bool aware_system_cabsignal = false;
-            bool aware_system_separate_acknowledge = false;
-            bool aware_system_sifa = false;
-
-            double aware_delay = 0.0;           // AwareDelay -> SecuritySystem->AwareDelay
-            double emergency_brake_delay = 0.0; // EmergencyBrakeDelay -> SecuritySystem->EmergencyBrakeDelay
-            EmergencyBrakeWarningSignal emergency_brake_warning_signal =
-                    BRAKE_WARNINGSIGNAL_SIREN_HIGHTONE; // EmergencyBrakeWarningSignal ->
-                                                        // EmergencyBrakeWarningSignal
-            bool radio_stop = true;                     // RadioStop -> SecuritySystem->radiostop_enabled
-            double sound_signal_delay = 0.0;            // SoundSignalDelay -> SecuritySystem->SoundSignalDelay
-            double shp_magnet_distance = 0.0;           // MagnetLocation -> SecuritySystem->MagnetLocation
-            double ca_max_hold_time = 0.0;              // MaxHoldTime -> SecuritySystem->MaxHoldTime
-
-        public:
             void security_acknowledge(bool p_enabled);
 
-            // Getters
-            bool get_aware_system_active() const;
-            bool get_aware_system_cabsignal() const;
-            bool get_aware_system_separate_acknowledge() const;
-            bool get_aware_system_sifa() const;
-            double get_aware_delay() const;
-            double get_emergency_brake_delay() const;
-            EmergencyBrakeWarningSignal get_emergency_brake_warning_signal() const;
-            bool get_radio_stop() const;
-            double get_sound_signal_delay() const;
-            double get_shp_magnet_distance() const;
-            double get_ca_max_hold_time() const;
-
-            // Setters
-            void set_aware_system_active(bool p_state);
-            void set_aware_system_cabsignal(bool p_state);
-            void set_aware_system_separate_acknowledge(bool p_state);
-            void set_aware_system_sifa(bool p_state);
-            void set_aware_delay(double value);
-            void set_emergency_brake_delay(double value);
-            void set_emergency_brake_warning_signal(EmergencyBrakeWarningSignal value);
-            void set_radio_stop(bool value);
-            void set_sound_signal_delay(double value);
-            void set_shp_magnet_distance(double value);
-            void set_ca_max_hold_time(double value);
+            MAKE_MEMBER_GS(bool, aware_system_active, false);
+            MAKE_MEMBER_GS(bool, aware_system_cab_signal, false);
+            MAKE_MEMBER_GS(bool, aware_system_separate_acknowledge, false);
+            MAKE_MEMBER_GS(bool, aware_system_sifa, false);
+            MAKE_MEMBER_GS(double, aware_delay, 0.0);
+            MAKE_MEMBER_GS(double, emergency_brake_delay, 0.0);
+            MAKE_MEMBER_GS_DIRTY(bool, radio_stop_enabled, false);
+            MAKE_MEMBER_GS(double, sound_signal_delay, 0.0);
+            MAKE_MEMBER_GS(double, shp_magnet_distance, 0.0);
+            MAKE_MEMBER_GS(double, ca_max_hold_time, 0.0);
+            MAKE_MEMBER_GS_NR(EmergencyBrakeWarningSignal, brake_warning_signal, EmergencyBrakeWarningSignal::BRAKE_WARNINGSIGNAL_SIREN_HIGHTONE);
     };
 } // namespace godot
 VARIANT_ENUM_CAST(TrainSecuritySystem::EmergencyBrakeWarningSignal)


### PR DESCRIPTION
By the beard of Merlin, prepare yourselves for a touch of true magic! This pull request, much like a well-brewed Polyjuice Potion, transmutes repetitive incantations into a single, potent spell.

No longer shall our code resemble a student's first attempt at a Transfiguration charm – clumsy and full of errant strokes? With the power of C++ macros, we've banished the tedious, repetitive boilerplate that once plagued our binding declarations. Think of it as a silencing charm for all that verbose grumbling!

This change introduces new, elegant macros that, with a mere flick of the wrist (or rather, a few lines of code), expand into the necessary incantations, ensuring consistency and drastically reducing the chances of a miscast. Our future coding endeavors shall be as swift and graceful as a Nimbus 2000!

### To do:
- [x] Replace code with macros everywhere in the project 
- [x] Adjust GDScript and XML docs to reflect any performed changes