### PR TITLE
Add TrainBuffCoupl support

### DIFF
--- a/demo/hud/mover_switches.tscn
+++ b/demo/hud/mover_switches.tscn
@@ -95,6 +95,19 @@ text = "Spring brake: Disable"
 command = "set_spring_brake_enabled"
 command_argument = "false"
 
+[node name="HBoxContainer6" type="HBoxContainer" parent="General"]
+layout_mode = 2
+
+[node name="Couple" parent="General/HBoxContainer6" instance=ExtResource("2_qbcao")]
+layout_mode = 2
+text = "Couple"
+command = "buffer_couple"
+
+[node name="Decouple" parent="General/HBoxContainer6" instance=ExtResource("2_qbcao")]
+layout_mode = 2
+text = "Decouple"
+command = "buffer_decouple"
+
 [node name="Security" type="HFlowContainer" parent="." unique_id=176203822]
 layout_mode = 2
 

--- a/demo/vehicles/sm42/sm_42v_1.tscn
+++ b/demo/vehicles/sm42/sm_42v_1.tscn
@@ -187,4 +187,6 @@ source/generator/engine = 0
 
 [node name="TrainLoad" type="TrainLoad" parent="." unique_id=829257758]
 
+[node name="TrainBuffer" type="TrainBuffCoupl" parent="."]
+
 [connection signal="selector_position_changed" from="TrainLightning" to="." method="_on_train_lightning_selector_position_changed"]

--- a/doc_classes/TrainBuffCoupl.xml
+++ b/doc_classes/TrainBuffCoupl.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TrainBuffCoupl" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Handles train buffers and coupling mechanisms.
+	</brief_description>
+	<description>
+		This class manages the physical properties and logic for train couplers and buffers. It allows configuring the stiffness, damping, and tolerance limits for both the buffer (compression) and coupler (tension) components. It also handles the connection capabilities such as air pipes, electric cables, and control signals.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="couple">
+			<return type="void" />
+			<description>
+				Attempts to couple the train to a neighboring vehicle.
+			</description>
+		</method>
+		<method name="decouple">
+			<return type="void" />
+			<description>
+				Decouples the train from the attached vehicle.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="allowed_flag" type="int" setter="set_allowed_flag" getter="get_allowed_flag" default="0">
+			Bitmask defining the allowed connections (mechanical, pneumatic, electric, etc.). See [enum AllowedFlagBits].
+		</member>
+		<member name="automatic_flag" type="int" setter="set_automatic_flag" getter="get_automatic_flag" default="0">
+			Bitmask defining which connections are established automatically during coupling.
+		</member>
+		<member name="buffer/max_compression_tolerance" type="float" setter="set_buffer_max_compression_tolerance" getter="get_buffer_max_compression_tolerance" default="0.1">
+			Maximum allowed compression distance for the buffer (in meters).
+		</member>
+		<member name="buffer/max_tension_tolerance" type="float" setter="set_buffer_max_tension_tolerance" getter="get_buffer_max_tension_tolerance" default="1000.0">
+			Maximum allowed tension force for the buffer (in kN).
+		</member>
+		<member name="buffer/stiffness_k" type="float" setter="set_buffer_stiffness_k" getter="get_buffer_stiffness_k" default="1.0">
+			Stiffness coefficient for the buffer.
+		</member>
+		<member name="control_type" type="String" setter="set_control_type" getter="get_control_type" default="&quot;&quot;">
+			Identifier for the control system type, used for checking compatibility between multiple units.
+		</member>
+		<member name="coupler/max_compression_tolerance" type="float" setter="set_coupler_max_compression_tolerance" getter="get_coupler_max_compression_tolerance" default="0.1">
+			Maximum allowed compression distance for the coupler (in meters).
+		</member>
+		<member name="coupler/max_tension_tolerance" type="float" setter="set_coupler_max_tension_tolerance" getter="get_coupler_max_tension_tolerance" default="1000.0">
+			Maximum allowed tension force for the coupler (in kN).
+		</member>
+		<member name="coupler/stiffness_k" type="float" setter="set_coupler_stiffness_k" getter="get_coupler_stiffness_k" default="1.0">
+			Stiffness coefficient for the coupler.
+		</member>
+		<member name="coupler/type" type="int" setter="set_coupler_type" getter="get_coupler_type" enum="TrainBuffCoupl.CouplerType" default="0">
+			The type of coupler mechanism (e.g., Automatic, Screw, Chain).
+		</member>
+		<member name="damping_beta" type="float" setter="set_damping_beta" getter="get_damping_beta" default="0.0">
+			Damping coefficient for the coupling physics.
+		</member>
+		<member name="power_coupling" type="int" setter="set_power_coupling" getter="get_power_coupling" default="128">
+			Bitmask defining which power lines can be coupled.
+		</member>
+		<member name="power_flag" type="int" setter="set_power_flag" getter="get_power_flag" default="0">
+			Bitmask indicating the current power capabilities available at the coupler.
+		</member>
+	</members>
+	<constants>
+		<constant name="COUPLER_TYPE_AUTOMATIC" value="0" enum="CouplerType">
+			Automatic coupler type (e.g., Scharfenberg, Janney).
+		</constant>
+		<constant name="COUPLER_TYPE_SCREW" value="1" enum="CouplerType">
+			Standard screw coupler.
+		</constant>
+		<constant name="COUPLER_TYPE_CHAIN" value="2" enum="CouplerType">
+			Chain coupler.
+		</constant>
+		<constant name="COUPLER_TYPE_BARE" value="3" enum="CouplerType">
+			Bare coupler (simplified or no mechanism).
+		</constant>
+		<constant name="COUPLER_TYPE_ARTICULATED" value="4" enum="CouplerType">
+			Articulated connection (permanent or semi-permanent).
+		</constant>
+		<constant name="ALLOWED_MECHANICAL" value="1" enum="AllowedFlagBits">
+			Allows mechanical coupling.
+		</constant>
+		<constant name="ALLOWED_BRAKE_PIPE" value="2" enum="AllowedFlagBits">
+			Allows brake pipe connection (pneumatic).
+		</constant>
+		<constant name="ALLOWED_MULTIPLE_CONTROL" value="4" enum="AllowedFlagBits">
+			Allows multiple unit control signal connection.
+		</constant>
+		<constant name="ALLOWED_HIGH_VOLTAGE" value="8" enum="AllowedFlagBits">
+			Allows high voltage heating connection.
+		</constant>
+		<constant name="ALLOWED_PASSAGE" value="16" enum="AllowedFlagBits">
+			Allows passenger/crew passage connection.
+		</constant>
+		<constant name="ALLOWED_AIR_8_BAR" value="32" enum="AllowedFlagBits">
+			Allows 8-bar air pipe connection (supply pipe).
+		</constant>
+		<constant name="ALLOWED_HEATING" value="64" enum="AllowedFlagBits">
+			Allows steam/electric heating connection.
+		</constant>
+		<constant name="ALLOWED_FIXED_COUPLING_LOCK" value="128" enum="AllowedFlagBits">
+			Indicates a fixed coupling lock.
+		</constant>
+		<constant name="ALLOWED_ELEC_24V" value="256" enum="AllowedFlagBits">
+			Allows 24V electric cable connection.
+		</constant>
+		<constant name="ALLOWED_ELEC_110V" value="512" enum="AllowedFlagBits">
+			Allows 110V electric cable connection.
+		</constant>
+		<constant name="ALLOWED_ELEC_3x400V" value="1024" enum="AllowedFlagBits">
+			Allows 3x400V electric cable connection.
+		</constant>
+		<constant name="POWER_24V" value="256" enum="PowerFlagBits">
+			Indicates presence of 24V power.
+		</constant>
+		<constant name="POWER_110V" value="512" enum="PowerFlagBits">
+			Indicates presence of 110V power.
+		</constant>
+		<constant name="POWER_3x400V" value="1024" enum="PowerFlagBits">
+			Indicates presence of 3x400V power.
+		</constant>
+	</constants>
+</class>

--- a/src/buffers/TrainBuffCoupl.cpp
+++ b/src/buffers/TrainBuffCoupl.cpp
@@ -1,0 +1,207 @@
+#include "TrainBuffCoupl.hpp"
+
+namespace godot {
+    void TrainBuffCoupl::_bind_methods() {
+        BIND_PROPERTY_W_HINT(
+                Variant::INT, "coupler_type", "coupler/type", &TrainBuffCoupl::set_coupler_type,
+                &TrainBuffCoupl::get_coupler_type, "value", PROPERTY_HINT_ENUM,
+                "Automatic,Screw,Chain,Bare,Articulated");
+
+        // Buffer properties
+        BIND_PROPERTY(
+                Variant::FLOAT, "buffer_stiffness_k", "buffer/stiffness_k", &TrainBuffCoupl::set_buffer_stiffness_k,
+                &TrainBuffCoupl::get_buffer_stiffness_k, "value");
+        BIND_PROPERTY(
+                Variant::FLOAT, "buffer_max_compression_tolerance", "buffer/max_compression_tolerance",
+                &TrainBuffCoupl::set_buffer_max_compression_tolerance, &TrainBuffCoupl::get_buffer_max_compression_tolerance,
+                "value");
+        BIND_PROPERTY(
+                Variant::FLOAT, "buffer_max_tension_tolerance", "buffer/max_tension_tolerance",
+                &TrainBuffCoupl::set_buffer_max_tension_tolerance, &TrainBuffCoupl::get_buffer_max_tension_tolerance,
+                "value");
+
+        // Coupler properties
+        BIND_PROPERTY(
+                Variant::FLOAT, "coupler_stiffness_k", "coupler/stiffness_k", &TrainBuffCoupl::set_coupler_stiffness_k,
+                &TrainBuffCoupl::get_coupler_stiffness_k, "value");
+        BIND_PROPERTY(
+                Variant::FLOAT, "coupler_max_compression_tolerance", "coupler/max_compression_tolerance",
+                &TrainBuffCoupl::set_coupler_max_compression_tolerance,
+                &TrainBuffCoupl::get_coupler_max_compression_tolerance, "value");
+        BIND_PROPERTY(
+                Variant::FLOAT, "coupler_max_tension_tolerance", "coupler/max_tension_tolerance",
+                &TrainBuffCoupl::set_coupler_max_tension_tolerance, &TrainBuffCoupl::get_coupler_max_tension_tolerance,
+                "value");
+
+        // Damping
+        BIND_PROPERTY(
+                Variant::FLOAT, "damping_beta", "damping_beta", &TrainBuffCoupl::set_damping_beta,
+                &TrainBuffCoupl::get_damping_beta, "value");
+
+        // Coupler capability flags and control
+        BIND_PROPERTY_W_HINT(
+                Variant::INT, "allowed_flag", "allowed_flag", &TrainBuffCoupl::set_allowed_flag,
+                &TrainBuffCoupl::get_allowed_flag, "value", PROPERTY_HINT_FLAGS,
+                "Mechanical,Brake pipe,Multiple control,High voltage,Passage,Air 8 bar,Heating,Fixed coupling lock,24V electric cable,110V electric cable,3+400V electric cable");
+        BIND_PROPERTY_W_HINT(
+                Variant::INT, "automatic_flag", "automatic_flag", &TrainBuffCoupl::set_automatic_flag,
+                &TrainBuffCoupl::get_automatic_flag, "value", PROPERTY_HINT_FLAGS,
+                "Mechanical,Brake pipe,Multiple control,High voltage,Passage,Air 8 bar,Heating,Fixed coupling lock,24V electric cable,110V electric cable,3+400V electric cable");
+        BIND_PROPERTY_W_HINT(
+                Variant::INT, "power_flag", "power_flag", &TrainBuffCoupl::set_power_flag, &TrainBuffCoupl::get_power_flag,
+                "value", PROPERTY_HINT_FLAGS, "24V,110V,3x400V");
+        BIND_PROPERTY_W_HINT(
+                Variant::INT, "power_coupling", "power_coupling", &TrainBuffCoupl::set_power_coupling,
+                &TrainBuffCoupl::get_power_coupling, "value", PROPERTY_HINT_FLAGS,
+                "Mechanical,Brake pipe,Multiple control,High voltage,Passage,Air 8 bar,Heating,Fixed coupling lock,24V electric cable,110V electric cable,3+400V electric cable");
+        BIND_PROPERTY(
+                Variant::STRING, "control_type", "control_type", &TrainBuffCoupl::set_control_type,
+                &TrainBuffCoupl::get_control_type, "value");
+        ClassDB::bind_method(D_METHOD("couple"), &TrainBuffCoupl::couple);
+        ClassDB::bind_method(D_METHOD("decouple"), &TrainBuffCoupl::decouple);
+
+        BIND_ENUM_CONSTANT(COUPLER_TYPE_AUTOMATIC)
+        BIND_ENUM_CONSTANT(COUPLER_TYPE_SCREW)
+        BIND_ENUM_CONSTANT(COUPLER_TYPE_CHAIN)
+        BIND_ENUM_CONSTANT(COUPLER_TYPE_BARE)
+        BIND_ENUM_CONSTANT(COUPLER_TYPE_ARTICULATED)
+
+        BIND_ENUM_CONSTANT(ALLOWED_MECHANICAL)
+        BIND_ENUM_CONSTANT(ALLOWED_BRAKE_PIPE)
+        BIND_ENUM_CONSTANT(ALLOWED_MULTIPLE_CONTROL)
+        BIND_ENUM_CONSTANT(ALLOWED_HIGH_VOLTAGE)
+        BIND_ENUM_CONSTANT(ALLOWED_PASSAGE)
+        BIND_ENUM_CONSTANT(ALLOWED_AIR_8_BAR)
+        BIND_ENUM_CONSTANT(ALLOWED_HEATING)
+        BIND_ENUM_CONSTANT(ALLOWED_FIXED_COUPLING_LOCK)
+        BIND_ENUM_CONSTANT(ALLOWED_ELEC_24V)
+        BIND_ENUM_CONSTANT(ALLOWED_ELEC_110V)
+        BIND_ENUM_CONSTANT(ALLOWED_ELEC_3x400V)
+
+        BIND_ENUM_CONSTANT(POWER_24V)
+        BIND_ENUM_CONSTANT(POWER_110V)
+        BIND_ENUM_CONSTANT(POWER_3x400V)
+    }
+
+    void TrainBuffCoupl::_do_update_internal_mover(TMoverParameters *mover) {
+        ASSERT_MOVER(mover)
+        TCoupling *coupler;
+        if (buffer_location == BufferLocation::BUFFER_LOCATION_FRONT) {
+            coupler = &mover->Couplers[0];
+        } else {
+            coupler = &mover->Couplers[1];
+        }
+        const double mass = train_controller_node->get_mass();
+        const double max_velocity = train_controller_node->get_max_velocity();
+        std::map<CouplerType, TCouplerType> _coupler_types{
+                {COUPLER_TYPE_AUTOMATIC, TCouplerType::Automatic},
+                {COUPLER_TYPE_SCREW, TCouplerType::Screw},
+                {COUPLER_TYPE_CHAIN, TCouplerType::Chain},
+                {COUPLER_TYPE_BARE, TCouplerType::Bare},
+                {COUPLER_TYPE_ARTICULATED, TCouplerType::Articulated},
+        };
+
+        const std::map<CouplerType, TCouplerType>::iterator lookup = _coupler_types.find(coupler_type);
+        const TCouplerType resolved_type = lookup != _coupler_types.end() ? lookup->second : TCouplerType::NoCoupler;
+
+        coupler->CouplerType = resolved_type;
+        coupler->SpringKC = coupler_stiffness_k;
+        coupler->DmaxC = coupler_max_compression_tolerance;
+        coupler->FmaxC = coupler_max_tension_tolerance;
+        coupler->SpringKB = buffer_stiffness_k;
+        coupler->DmaxB = buffer_max_compression_tolerance;
+        coupler->FmaxB = buffer_max_tension_tolerance;
+        coupler->beta = damping_beta;
+        coupler->AutomaticCouplingFlag = automatic_flag;
+        coupler->AllowedFlag = allowed_flag;
+        if (coupler->AllowedFlag < 0) {
+            coupler->AllowedFlag = -coupler->AllowedFlag | coupling::permanent;
+        }
+
+        coupler->PowerCoupling = power_coupling;
+        coupler->PowerFlag = power_flag;
+        coupler->control_type = control_type.ascii();
+
+        if (coupler->CouplerType != TCouplerType::NoCoupler
+            && coupler->CouplerType != TCouplerType::Bare
+            && coupler->CouplerType != TCouplerType::Articulated) {
+
+            coupler->SpringKC *= 1000;
+            coupler->FmaxC *= 1000;
+            coupler->SpringKB *= 1000;
+            coupler->FmaxB *= 1000;
+        } else if (coupler->CouplerType == TCouplerType::Bare) {
+            coupler->SpringKC = (50.0 * mass) + (max_velocity / 0.05);
+            coupler->DmaxC = 0.05;
+            coupler->FmaxC = (100.0 * mass) + (2 * max_velocity);
+            coupler->SpringKB = (60.0 * mass) + (max_velocity / 0.05);
+            coupler->DmaxB = 0.05;
+            coupler->FmaxB = (50.0 * mass) + (2.0 * max_velocity);
+            coupler->beta = 0.3;
+        } else if (coupler->CouplerType == TCouplerType::Articulated) {
+            coupler->SpringKC = 4500 * 1000;
+            coupler->DmaxC = 0.05;
+            coupler->FmaxC = 850 * 1000;
+            coupler->SpringKB = 9200 * 1000;
+            coupler->DmaxB = 0.05;
+            coupler->FmaxB = 320 * 1000;
+            coupler->beta = 0.55;
+        }
+
+        if (buffer_location == BufferLocation::BUFFER_LOCATION_BOTH) {
+            mover->Couplers[0] = mover->Couplers[1];
+        }
+    }
+
+    void TrainBuffCoupl::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {
+        // Expose the current config / state if needed
+    }
+
+    void TrainBuffCoupl::_do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) {
+        // Provide config dictionary entries
+        config.set("buffer_stiffness_k", buffer_stiffness_k);
+        config.set("buffer_max_compression_tolerance", buffer_max_compression_tolerance);
+        config.set("buffer_max_tension_tolerance", buffer_max_tension_tolerance);
+        config.set("coupler_stiffness_k", coupler_stiffness_k);
+        config.set("coupler_max_compression_tolerance", coupler_max_compression_tolerance);
+        config.set("coupler_max_tension_tolerance", coupler_max_tension_tolerance);
+        config.set("damping_beta", damping_beta);
+
+        // New flags and control properties
+        config.set("allowed_flag", allowed_flag);
+        config.set("automatic_flag", automatic_flag);
+        config.set("power_flag", power_flag);
+        config.set("power_coupling", power_coupling);
+        config.set("control_type", control_type);
+    }
+
+    void TrainBuffCoupl::_register_commands() {
+        register_command("buffer_couple", Callable(this, "couple"));
+        register_command("buffer_decouple", Callable(this, "decouple"));
+        TrainPart::_register_commands();
+    }
+
+    void TrainBuffCoupl::_unregister_commands() {
+        unregister_command("buffer_couple", Callable(this, "couple"));
+        unregister_command("buffer_decouple", Callable(this, "decouple"));
+        TrainPart::_unregister_commands();
+
+    }
+
+    void TrainBuffCoupl::couple() {
+        const TMoverParameters *mover = get_mover();
+        ASSERT_MOVER(mover);
+
+        UtilityFunctions::push_warning("[TrainBuffCoupl] Coupling is not supported yet as it requires to handle logic between 2 vehicles simultaneously");
+        log_warning("[TrainBuffCoupl] Coupling is not supported yet as it requires to handle logic between 2 vehicles simultaneously");
+    }
+
+    void TrainBuffCoupl::decouple() {
+        TMoverParameters *mover = get_mover();
+        ASSERT_MOVER(mover);
+
+        UtilityFunctions::push_warning("[TrainBuffCoupl] Decoupling is not supported yet as it requires to handle logic between 2 vehicles simultaneously");
+        log_warning("[TrainBuffCoupl] Decoupling is not supported yet as it requires to handle logic between 2 vehicles simultaneously");
+    }
+} //namespace godot
+

--- a/src/buffers/TrainBuffCoupl.hpp
+++ b/src/buffers/TrainBuffCoupl.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#include "../core/TrainPart.hpp"
+#include "macros.hpp"
+
+namespace godot {
+    class TrainController;
+    class TrainBuffCoupl: public TrainPart {
+            GDCLASS(TrainBuffCoupl, TrainPart);
+        private:
+            static void _bind_methods();
+        protected:
+            void _do_update_internal_mover(TMoverParameters *mover) override;
+            void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
+            void _do_fetch_config_from_mover(TMoverParameters *mover, Dictionary &config) override;
+            void _register_commands() override;
+            void _unregister_commands() override;
+        public:
+            enum CouplerType {
+                COUPLER_TYPE_AUTOMATIC,
+                COUPLER_TYPE_SCREW,
+                COUPLER_TYPE_CHAIN,
+                COUPLER_TYPE_BARE,
+                COUPLER_TYPE_ARTICULATED
+            };
+
+            // Bit-flag enums for coupler features and power transfer
+            enum AllowedFlagBits {
+                ALLOWED_MECHANICAL = 1,
+                ALLOWED_BRAKE_PIPE = 2,
+                ALLOWED_MULTIPLE_CONTROL = 4,
+                ALLOWED_HIGH_VOLTAGE = 8,
+                ALLOWED_PASSAGE = 16,
+                ALLOWED_AIR_8_BAR = 32,
+                ALLOWED_HEATING = 64,
+                ALLOWED_FIXED_COUPLING_LOCK = 128,
+                // The following are only valid together with fixed coupling lock, but included for completeness
+                ALLOWED_ELEC_24V = 256,
+                ALLOWED_ELEC_110V = 512,
+                ALLOWED_ELEC_3x400V = 1024
+            };
+
+            enum PowerFlagBits {
+                POWER_24V = 256,
+                POWER_110V = 512,
+                POWER_3x400V = 1024
+            };
+
+            enum BufferLocation {
+                BUFFER_LOCATION_FRONT,
+                BUFFER_LOCATION_BACK,
+                BUFFER_LOCATION_BOTH
+            };
+
+            MAKE_MEMBER_GS(double, buffer_stiffness_k, 1.0);
+            MAKE_MEMBER_GS(double, buffer_max_compression_tolerance, 0.1);
+            MAKE_MEMBER_GS(double, buffer_max_tension_tolerance, 1000.0);
+            MAKE_MEMBER_GS(double, coupler_stiffness_k, 1.0);
+            MAKE_MEMBER_GS(double, coupler_max_compression_tolerance, 0.1);
+            MAKE_MEMBER_GS(double, coupler_max_tension_tolerance, 1000.0);
+            MAKE_MEMBER_GS(double, damping_beta, 0.0);
+            MAKE_MEMBER_GS(int, allowed_flag, 0);
+            MAKE_MEMBER_GS(int, automatic_flag, 0);
+            MAKE_MEMBER_GS(int, power_flag, 0);
+            MAKE_MEMBER_GS(int, power_coupling, 128);
+            MAKE_MEMBER_GS(String, control_type, "");
+            MAKE_MEMBER_GS_NR(CouplerType, coupler_type, CouplerType::COUPLER_TYPE_AUTOMATIC);
+            MAKE_MEMBER_GS_NR(BufferLocation, buffer_location, BufferLocation::BUFFER_LOCATION_FRONT);
+
+            void couple();
+            void decouple();
+    };
+} //namespace godot
+
+VARIANT_ENUM_CAST(TrainBuffCoupl::CouplerType)
+VARIANT_ENUM_CAST(TrainBuffCoupl::AllowedFlagBits)
+VARIANT_ENUM_CAST(TrainBuffCoupl::PowerFlagBits)
+VARIANT_ENUM_CAST(TrainBuffCoupl::BufferLocation)

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,7 +1,7 @@
-#include "register_types.h"
 #include "brakes/TrainBrake.hpp"
 #include "brakes/TrainElectroPneumaticDynamicBrake.hpp"
 #include "brakes/TrainSpringBrake.hpp"
+#include "buffers/TrainBuffCoupl.hpp"
 #include "core/GameLog.hpp"
 #include "core/GenericTrainPart.hpp"
 #include "core/TrainController.hpp"
@@ -16,6 +16,7 @@
 #include "lighting/TrainLighting.hpp"
 #include "load/TrainLoad.hpp"
 #include "parsers/maszyna_parser.hpp"
+#include "register_types.h"
 #include "resources/engines/MotorParameter.hpp"
 #include "resources/engines/WWListItem.hpp"
 #include "resources/lighting/LightListItem.hpp"
@@ -73,18 +74,19 @@ void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
         GDREGISTER_CLASS(WWListItem);
         GDREGISTER_CLASS(MotorParameter);
         GDREGISTER_CLASS(LightListItem)
-        GDREGISTER_CLASS(TrainElectroPneumaticDynamicBrake);
-        GDREGISTER_CLASS(TrainLoad);
-        GDREGISTER_CLASS(LoadListItem);
         GDREGISTER_CLASS(MaterialParser);
         GDREGISTER_CLASS(MaterialManager);
         GDREGISTER_CLASS(MaszynaMaterial);
+        GDREGISTER_CLASS(TrainElectroPneumaticDynamicBrake)
+        GDREGISTER_CLASS(TrainLoad)
+        GDREGISTER_CLASS(LoadListItem)
+        GDREGISTER_CLASS(TrainBuffCoupl)
 
         if (!is_doctool_mode()) {
             train_system_singleton = memnew(TrainSystem);
             game_log_singleton = memnew(GameLog);
             material_manager_singleton = memnew(MaterialManager);
-            
+
             Engine::get_singleton()->register_singleton("TrainSystem", train_system_singleton);
             Engine::get_singleton()->register_singleton("GameLog", game_log_singleton);
             Engine::get_singleton()->register_singleton("MaterialManager", material_manager_singleton);


### PR DESCRIPTION
Logic is implemented only partially, because of the fact that Mover's coupling logic relies on a big part of MaSzyna's original code that we'll have to implement in our own way probably, in the future