### PR TITLE
Add RailVehicle and Track physics using PhysicsServer3D and optimize rendering in C++

### DIFF
--- a/addons/libmaszyna/maszyna_track_3d.gd
+++ b/addons/libmaszyna/maszyna_track_3d.gd
@@ -153,19 +153,7 @@ func _update_track():
 
 func _update_rail_mesh(length: float):
     if length < 0.1: return
-    
-    var should_generate = _rail_mesh == null
-    if _rail_mesh:
-        var old_length = _rail_mesh.get_meta("length", 0.0)
-        var old_spacing = _rail_mesh.get_meta("rail_spacing", 0.0)
-        if abs(old_length - length) > 1.0 or abs(old_spacing - rail_spacing) > 0.001:
-            should_generate = true
-        
-    if should_generate:
-         _generate_template_mesh(length)
-         if _rail_mesh:
-             _rail_mesh.set_meta("length", length)
-             _rail_mesh.set_meta("rail_spacing", rail_spacing)
+    _generate_template_mesh(length)
 
 func _apply_3_point_logic_optimized():
     if not curve or curve.point_count < 2: return
@@ -248,60 +236,8 @@ func _prepare_path_data() -> Dictionary:
     }
 
 func _generate_template_mesh(length: float):
-    var rail_poly = [
-        Vector2(-0.075, 0.0), Vector2(0.075, 0.0), Vector2(0.075, 0.015), Vector2(0.02, 0.03),
-        Vector2(0.02, 0.12), Vector2(0.04, 0.13), Vector2(0.04, 0.16), Vector2(-0.04, 0.16),
-        Vector2(-0.04, 0.13), Vector2(-0.02, 0.12), Vector2(-0.02, 0.03), Vector2(-0.075, 0.015),
-    ]
-    
-    var steps = max(2, floor(length / curve_precision))
-    var vertices = PackedVector3Array()
-    var normals = PackedVector3Array()
-    var uvs = PackedVector2Array()
-    var indices = PackedInt32Array()
-    var offset = rail_spacing * 0.5
-    
-    var poly_size = rail_poly.size()
-    
-    for i in range(steps + 1):
-        var z = (float(i) / steps) * length
-        var v_u = float(i) / steps * length
-        for side in [-1, 1]:
-            for j in range(poly_size):
-                var p = rail_poly[j]
-                var x_pos = (side * offset) + (p.x * side)
-                vertices.append(Vector3(x_pos, p.y, z))
-                normals.append(Vector3(p.x, p.y - 0.08, 0.0).normalized())
-                uvs.append(Vector2(float(j) / (poly_size - 1), v_u))
-                
-    var v_per_step = poly_size * 2
-    for i in range(steps):
-        for side_idx in range(2):
-            var side_off = side_idx * poly_size
-            for j in range(poly_size):
-                var next_j = (j + 1) % poly_size
-                var curr = i * v_per_step + side_off + j
-                var next = i * v_per_step + side_off + next_j
-                var step_curr = (i + 1) * v_per_step + side_off + j
-                var step_next = (i + 1) * v_per_step + side_off + next_j
-                if side_idx == 1:
-                    indices.append(curr); indices.append(next); indices.append(step_curr)
-                    indices.append(next); indices.append(step_next); indices.append(step_curr)
-                else:
-                    indices.append(curr); indices.append(step_curr); indices.append(next)
-                    indices.append(next); indices.append(step_curr); indices.append(step_next)
-
-    var arrays = []; arrays.resize(Mesh.ARRAY_MAX)
-    arrays[Mesh.ARRAY_VERTEX] = vertices
-    arrays[Mesh.ARRAY_NORMAL] = normals
-    arrays[Mesh.ARRAY_TEX_UV] = uvs
-    arrays[Mesh.ARRAY_INDEX] = indices
-    
-    _rail_mesh = ArrayMesh.new()
-    _rail_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
-    _rail_mesh.set_meta("length", length)
-    
-    RenderingServer.instance_set_base(_renderer.get_rail_mesh_instance(), _rail_mesh.get_rid())
+    if _renderer:
+        _renderer.update_rail_mesh(length, rail_spacing, curve_precision)
 
 # Helper to get the RID from the renderer (we should add this to C++)
 func get_rail_instance_rid() -> RID:

--- a/addons/libmaszyna/rail_vehicle_3d.gd
+++ b/addons/libmaszyna/rail_vehicle_3d.gd
@@ -85,6 +85,14 @@ var _wheel_nodes: Array[Node3D] = []
 var _wheel_angles: Array[float] = [] # Current rotation angle for each wheel
 var _rest_transforms: Dictionary = {} # Stores Node -> Transform3D relative to RailVehicle3D root
 var _local_rest_bases: Dictionary = {} # Stores Node -> Basis (local)
+var _physics_body: RID
+var _physics_shape: RID
+@export var physics_box_size: Vector3 = Vector3(3.0, 4.0, 15.0):
+    set(x):
+        physics_box_size = x
+        if _is_physics_registered and _physics_shape.is_valid():
+            PhysicsServer3D.shape_set_data(_physics_shape, physics_box_size * 0.5)
+var _is_physics_registered: bool = false
 
 
 # Calculate Transform3D relative to RailVehicle3D root using ONLY local transforms
@@ -336,12 +344,13 @@ func _process(delta):
             var b1 = _bogie_nodes[0]
             var b2 = _bogie_nodes[1]
             
-            # 1. Update bogies FIRST
-            _update_attached_nodes([b1, b2])
+            # 1. Calculate theoretical global transforms of bogies FIRST without displacing the parent
+            var t1 = _get_node_track_transform(b1)
+            var t2 = _get_node_track_transform(b2)
             
-            # 2. Position car based on bogies
-            var p1 = b1.global_position
-            var p2 = b2.global_position
+            # 2. Position car based on theoretical bogies' tracks
+            var p1 = t1.origin
+            var p2 = t2.origin
             
             # Design-time local positions of bogies (to find the car's center relative to them)
             var rb1_z = _rest_transforms[b1].origin.z
@@ -368,7 +377,7 @@ func _process(delta):
                 car_z = -car_z
                 
             # For the Up vector, we can average the bogies' Up vectors or use the track's Up at car_pos
-            var car_up = (b1.global_transform.basis.y + b2.global_transform.basis.y).normalized()
+            var car_up = (t1.basis.y + t2.basis.y).normalized()
             
             # Construct the car's global transform
             # Godot uses Y-up, -Z forward (MaSzyna uses -Z forward too in E3D, but here we align to track)
@@ -379,22 +388,24 @@ func _process(delta):
             
             var car_gt = Transform3D(car_basis, car_pos)
             
-            for node in _car_nodes:
-                var rest_t = _rest_transforms.get(node)
-                if not rest_t:
-                    rest_t = _get_relative_transform(node)
-                    _rest_transforms[node] = rest_t
-                # Remove Z from rest transform because we already accounted for bogie-to-car-center distance
-                var rest_t_no_z = rest_t
-                rest_t_no_z.origin.z = 0
-                node.global_transform = car_gt * rest_t_no_z
-                
+            # Apply the global transform to the parent (self).
+            self.global_transform = car_gt
+
+            # Now explicitly update bogies so they rotate to follow the track curve
+            _update_attached_nodes([b1, b2])
+
             _animate_wheels(delta)
+
+            if _is_physics_registered and _physics_body.is_valid():
+                PhysicsServer3D.body_set_state(_physics_body, PhysicsServer3D.BODY_STATE_TRANSFORM, self.global_transform)
         else:
             # Fallback to legacy single-point snapping if not exactly 2 bogies
             _update_attached_nodes(_car_nodes)
             _update_attached_nodes(_bogie_nodes)
             _animate_wheels(delta)
+
+            if _is_physics_registered and _physics_body.is_valid():
+                PhysicsServer3D.body_set_state(_physics_body, PhysicsServer3D.BODY_STATE_TRANSFORM, self.global_transform)
     else:
         _animate_wheels(delta)
 
@@ -440,6 +451,47 @@ func _animate_wheels(delta: float):
         # Apply rotation relative to its local rest basis around the local X axis
         wheel.transform.basis = rest_basis * Basis(Vector3.RIGHT, _wheel_angles[i])
 
+
+func _get_node_track_transform(node: Node3D) -> Transform3D:
+    var rest_t = _rest_transforms.get(node)
+    if not rest_t:
+        rest_t = _get_relative_transform(node)
+        _rest_transforms[node] = rest_t
+
+    var dz = rest_t.origin.z
+    var target_dist = distance_on_track + dz
+    var current_track = _track
+
+    var max_traversals = 5
+    while max_traversals > 0:
+        var length = current_track.curve.get_baked_length()
+        if target_dist < 0:
+            var prev = _get_next_connected_track(current_track, false)
+            if prev:
+                target_dist += prev.curve.get_baked_length()
+                current_track = prev
+                max_traversals -= 1
+                continue
+        elif target_dist > length:
+            var next = _get_next_connected_track(current_track, true)
+            if next:
+                target_dist -= length
+                current_track = next
+                max_traversals -= 1
+                continue
+        break
+
+    var ct = current_track.global_transform * current_track.curve.sample_baked_with_rotation(target_dist)
+    var target_basis = ct.basis
+    if not track_reverse:
+        target_basis = target_basis.rotated(target_basis.y.normalized(), PI)
+
+    if current_track.has_method("get_rail_top_vertical_offset"):
+        ct.origin += target_basis.y.normalized() * current_track.get_rail_top_vertical_offset()
+
+    var rest_t_no_z = rest_t
+    rest_t_no_z.origin.z = 0
+    return Transform3D(target_basis, ct.origin) * rest_t_no_z
 
 func _update_attached_nodes(nodes: Array):
     for node in nodes:
@@ -496,3 +548,22 @@ func _ready() -> void:
         if child.has_signal("e3d_loaded"):
             if not child.e3d_loaded.is_connected(_on_e3d_loaded):
                 child.e3d_loaded.connect(_on_e3d_loaded)
+
+    if not Engine.is_editor_hint():
+        _physics_body = PhysicsServer3D.body_create()
+        PhysicsServer3D.body_set_mode(_physics_body, PhysicsServer3D.BODY_MODE_KINEMATIC)
+        _physics_shape = PhysicsServer3D.box_shape_create()
+        PhysicsServer3D.shape_set_data(_physics_shape, physics_box_size * 0.5) # Half-extents
+        PhysicsServer3D.body_add_shape(_physics_body, _physics_shape)
+        PhysicsServer3D.body_set_space(_physics_body, get_world_3d().space)
+        _is_physics_registered = true
+
+func _exit_tree() -> void:
+    if _is_physics_registered:
+        if _physics_body.is_valid():
+            PhysicsServer3D.free_rid(_physics_body)
+            _physics_body = RID()
+        if _physics_shape.is_valid():
+            PhysicsServer3D.free_rid(_physics_shape)
+            _physics_shape = RID()
+        _is_physics_registered = false

--- a/src/models/TrackRenderer.cpp
+++ b/src/models/TrackRenderer.cpp
@@ -20,6 +20,7 @@ namespace godot {
     void TrackRenderer::_bind_methods() {
         ClassDB::bind_method(
                 D_METHOD("update_track_data", "points", "quats", "length"), &TrackRenderer::update_track_data);
+        ClassDB::bind_method(D_METHOD("update_rail_mesh", "length", "rail_spacing", "curve_precision"), &TrackRenderer::update_rail_mesh);
         ClassDB::bind_method(D_METHOD("set_rail_material", "material"), &TrackRenderer::set_rail_material);
         ClassDB::bind_method(D_METHOD("get_rail_material"), &TrackRenderer::get_rail_material);
         ClassDB::bind_method(D_METHOD("set_sleeper_mesh", "mesh"), &TrackRenderer::set_sleeper_mesh);
@@ -58,7 +59,6 @@ namespace godot {
 
     TrackRenderer::TrackRenderer() {
         RenderingServer *rs = RenderingServer::get_singleton();
-        PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
 
         // Create rail instance
         rail_mesh_instance = rs->instance_create();
@@ -69,14 +69,13 @@ namespace godot {
         rs->instance_set_base(sleeper_multimesh_instance, sleeper_multimesh);
 
         // Create physics
-        physics_body = ps->body_create();
-        ps->body_set_mode(physics_body, PhysicsServer3D::BODY_MODE_STATIC);
-        ps->body_set_collision_layer(physics_body, 1);
-        ps->body_set_collision_mask(physics_body, 1);
-        physics_shape = ps->concave_polygon_shape_create();
-        ps->body_add_shape(physics_body, physics_shape);
+        physics_shape.instantiate();
+        shape_owner_id = shape_owner_create(this);
+        shape_owner_add_shape(shape_owner_id, physics_shape);
 
         collision_enabled = true;
+        set_collision_layer(1);
+        set_collision_mask(1);
 
         set_notify_transform(true);
     }
@@ -105,14 +104,6 @@ namespace godot {
         if (sleeper_multimesh.is_valid()) {
             rs->free_rid(sleeper_multimesh);
         }
-
-        PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
-        if (physics_body.is_valid()) {
-            ps->free_rid(physics_body);
-        }
-        if (physics_shape.is_valid()) {
-            ps->free_rid(physics_shape);
-        }
     }
 
     void TrackRenderer::_ready() {
@@ -127,9 +118,6 @@ namespace godot {
         RenderingServer *rs = RenderingServer::get_singleton();
         rs->instance_set_scenario(rail_mesh_instance, RID());
         rs->instance_set_scenario(sleeper_multimesh_instance, RID());
-
-        PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
-        ps->body_set_space(physics_body, RID());
     }
 
     void TrackRenderer::_update_render_instances() {
@@ -152,10 +140,8 @@ namespace godot {
         rs->instance_set_transform(rail_mesh_instance, gt);
         rs->instance_set_transform(sleeper_multimesh_instance, gt);
 
-        PhysicsServer3D *ps = PhysicsServer3D::get_singleton();
-        const RID space = visible && collision_enabled ? world->get_space() : RID();
-        ps->body_set_space(physics_body, space);
-        ps->body_set_state(physics_body, PhysicsServer3D::BODY_STATE_TRANSFORM, gt);
+        // StaticBody3D properties will automatically follow global_transform and visibility
+        shape_owner_set_disabled(shape_owner_id, !(visible && collision_enabled));
     }
 
     void TrackRenderer::update_track_data(
@@ -296,10 +282,11 @@ namespace godot {
                 }
             }
 
-            Dictionary shape_data;
-            shape_data["faces"] = collision_faces;
-            PhysicsServer3D::get_singleton()->shape_set_data(physics_shape, shape_data);
+            physics_shape->set_faces(collision_faces);
+            physics_shape->set_backface_collision(true);
         }
+
+        _update_render_instances();
     }
 
     void TrackRenderer::set_rail_material(const Ref<ShaderMaterial> &p_material) {
@@ -337,4 +324,107 @@ namespace godot {
         return sleeper_material;
     }
 
+
+    void TrackRenderer::update_rail_mesh(float length, float rail_spacing, float curve_precision) {
+        if (length < 0.1f) return;
+
+        // Cache mechanism
+        float old_length = 0.0f;
+        float old_spacing = 0.0f;
+        if (internal_rail_mesh.is_valid()) {
+            old_length = internal_rail_mesh->get_meta("length", 0.0f);
+            old_spacing = internal_rail_mesh->get_meta("rail_spacing", 0.0f);
+        }
+
+        bool should_generate = internal_rail_mesh.is_null();
+        if (!should_generate) {
+            if (std::abs(old_length - length) > 1.0f || std::abs(old_spacing - rail_spacing) > 0.001f) {
+                should_generate = true;
+            }
+        }
+
+        if (!should_generate) return;
+
+        if (length < 0.1f) return;
+
+        int steps = std::max(2, static_cast<int>(std::floor(length / curve_precision)));
+
+        PackedVector2Array rail_poly;
+        rail_poly.push_back(Vector2(-0.075f, 0.0f));
+        rail_poly.push_back(Vector2(0.075f, 0.0f));
+        rail_poly.push_back(Vector2(0.075f, 0.015f));
+        rail_poly.push_back(Vector2(0.02f, 0.03f));
+        rail_poly.push_back(Vector2(0.02f, 0.12f));
+        rail_poly.push_back(Vector2(0.04f, 0.13f));
+        rail_poly.push_back(Vector2(0.04f, 0.16f));
+        rail_poly.push_back(Vector2(-0.04f, 0.16f));
+        rail_poly.push_back(Vector2(-0.04f, 0.13f));
+        rail_poly.push_back(Vector2(-0.02f, 0.12f));
+        rail_poly.push_back(Vector2(-0.02f, 0.03f));
+        rail_poly.push_back(Vector2(-0.075f, 0.015f));
+
+        PackedVector3Array vertices;
+        PackedVector3Array normals;
+        PackedVector2Array uvs;
+        PackedInt32Array indices;
+
+        float offset = rail_spacing * 0.5f;
+        int poly_size = rail_poly.size();
+
+        for (int i = 0; i <= steps; i++) {
+            float z = (static_cast<float>(i) / steps) * length;
+            float v_u = (static_cast<float>(i) / steps) * length;
+
+            int sides[2] = {-1, 1};
+            for (int s = 0; s < 2; s++) {
+                int side = sides[s];
+                for (int j = 0; j < poly_size; j++) {
+                    Vector2 p = rail_poly[j];
+                    float x_pos = (side * offset) + (p.x * side);
+                    vertices.push_back(Vector3(x_pos, p.y, z));
+                    normals.push_back(Vector3(p.x, p.y - 0.08f, 0.0f).normalized());
+                    uvs.push_back(Vector2(static_cast<float>(j) / (poly_size - 1), v_u));
+                }
+            }
+        }
+
+        int v_per_step = poly_size * 2;
+        for (int i = 0; i < steps; i++) {
+            for (int side_idx = 0; side_idx < 2; side_idx++) {
+                int side_off = side_idx * poly_size;
+                for (int j = 0; j < poly_size; j++) {
+                    int next_j = (j + 1) % poly_size;
+                    int curr = i * v_per_step + side_off + j;
+                    int next = i * v_per_step + side_off + next_j;
+                    int step_curr = (i + 1) * v_per_step + side_off + j;
+                    int step_next = (i + 1) * v_per_step + side_off + next_j;
+
+                    if (side_idx == 1) {
+                        indices.push_back(curr); indices.push_back(next); indices.push_back(step_curr);
+                        indices.push_back(next); indices.push_back(step_next); indices.push_back(step_curr);
+                    } else {
+                        indices.push_back(curr); indices.push_back(step_curr); indices.push_back(next);
+                        indices.push_back(next); indices.push_back(step_curr); indices.push_back(step_next);
+                    }
+                }
+            }
+        }
+
+        Array arrays;
+        arrays.resize(Mesh::ARRAY_MAX);
+        arrays[Mesh::ARRAY_VERTEX] = vertices;
+        arrays[Mesh::ARRAY_NORMAL] = normals;
+        arrays[Mesh::ARRAY_TEX_UV] = uvs;
+        arrays[Mesh::ARRAY_INDEX] = indices;
+
+        Ref<ArrayMesh> new_mesh;
+        new_mesh.instantiate();
+        new_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
+
+        internal_rail_mesh = new_mesh;
+        internal_rail_mesh->set_meta("length", length);
+        internal_rail_mesh->set_meta("rail_spacing", rail_spacing);
+        rail_mesh = internal_rail_mesh->get_rid();
+        RenderingServer::get_singleton()->instance_set_base(rail_mesh_instance, rail_mesh);
+    }
 } // namespace godot

--- a/src/models/TrackRenderer.hpp
+++ b/src/models/TrackRenderer.hpp
@@ -1,16 +1,18 @@
 #ifndef TRACK_RENDERER_HPP
 #define TRACK_RENDERER_HPP
 
-#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/classes/static_body3d.hpp>
+#include <godot_cpp/classes/concave_polygon_shape3d.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
 #include <godot_cpp/classes/multi_mesh.hpp>
 #include <godot_cpp/classes/shader_material.hpp>
+#include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/variant/rid.hpp>
 
 namespace godot {
 
-class TrackRenderer : public Node3D {
-    GDCLASS(TrackRenderer, Node3D)
+class TrackRenderer : public StaticBody3D {
+    GDCLASS(TrackRenderer, StaticBody3D)
 
 private:
     RID scenario;
@@ -18,6 +20,7 @@ private:
     // Rail rendering
     RID rail_mesh_instance;
     RID rail_mesh;
+    Ref<ArrayMesh> internal_rail_mesh;
     Ref<ShaderMaterial> rail_material;
     
     // Sleeper rendering
@@ -35,8 +38,8 @@ private:
     float rail_spacing = 1.6f;
     bool collision_enabled = true;
 
-    RID physics_body;
-    RID physics_shape;
+    uint32_t shape_owner_id = 0;
+    Ref<ConcavePolygonShape3D> physics_shape;
 
     void _update_render_instances();
 
@@ -52,6 +55,7 @@ public:
     void _exit_tree() override;
 
     void update_track_data(const PackedVector4Array &p_points, const PackedVector4Array &p_quats, float p_length);
+    void update_rail_mesh(float length, float rail_spacing, float curve_precision);
     
     void set_rail_material(const Ref<ShaderMaterial> &p_material);
     Ref<ShaderMaterial> get_rail_material() const;


### PR DESCRIPTION
Implemented physics bodies for both the rails (using `TrackRenderer` as a `StaticBody3D`) and cars (`PhysicsServer3D` kinematic bodies). Rewrote car alignment logic to strictly use the 2 bogies as pivot points and ported track mesh generation to C++ for improved optimization.

---
*PR created automatically by Jules for task [7049054911670910815](https://jules.google.com/task/7049054911670910815) started by @JezSonic*