### PR TITLE
(#175) Fix alerter acknowledgment issue

### DIFF
--- a/src/systems/TrainSecuritySystem.cpp
+++ b/src/systems/TrainSecuritySystem.cpp
@@ -91,7 +91,7 @@ namespace godot {
     void TrainSecuritySystem::security_acknowledge(const bool p_enabled) {
         TMoverParameters *mover = get_mover();
         ASSERT_MOVER(mover);
-        if (enabled) {
+        if (p_enabled) {
             mover->SecuritySystem.acknowledge_press();
         } else {
             mover->SecuritySystem.acknowledge_release();


### PR DESCRIPTION
Use p_enabled parameter instead of inherited enabled from TrainPart to ensure correct acknowledgment behavior.