### PR TITLE
Dev/code format fixer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks: "bugprone-*,
   -modernize-use-auto,
   -*-pro-bounds-constant-array-index,
   -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
   -*-pro-type-const-cast,
   -*-pro-type-reinterpret-cast,
   -llvm-header-guard,
@@ -52,6 +53,10 @@ Checks: "bugprone-*,
   -*-pro-bounds-avoid-unchecked-container-access,
   -*-unnecessary-value-param"
 WarningsAsErrors: "*"
+HeaderFilterRegex: '$^'
+ExcludeHeaderFilterRegex: '(^|.*/)(maszyna|gen|godot-cpp)/'
+RemovedArgs:
+  - '-fno-gnu-unique'
 CheckOptions:
   - key: bugprone-reserved-identifier.AllowedIdentifiers
     value: 'GDCLASS;VARIANT_ENUM_CAST'

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+CompileFlags:
+  CompilationDatabase: .
+  Remove:
+    - "-fno-gnu-unique"
+  Add:
+    - "-Wno-macro-redefined"

--- a/.vimrc
+++ b/.vimrc
@@ -3,14 +3,23 @@ set expandtab
 let &path.= "godot-cpp/gen/include,godot-cpp/gdextension/godot-cpp/inlcude,"
 
 let g:ale_fixers = {
-    \ 'cpp' : ['clang-format'],
-    \ 'hpp' : ['clang-format']
+    \ 'hpp': ['clang-format'],
+    \ 'h': ['clang-format'],
+    \ 'c': ['clang-format'],
+    \ 'cpp': ['clang-format']
     \}
 
 let g:ale_linters = {
-    \ 'cpp' : ['clangtidy'],
-    \ 'hpp' : ['clangtidy']
+    \ 'h': ['clangtidy'],
+    \ 'hpp': ['clangtidy'],
+    \ 'c': ['clangtidy'],
+    \ 'cpp': ['clangtidy']
     \}
+
+let g:ale_c_clangformat_options = '--style=file'
+let g:ale_cpp_clangformat_options = '--style=file'
+let g:ale_c_clangtidy_extra_options = '-extra-arg=-Wno-macro-redefined'
+let g:ale_cpp_clangtidy_extra_options = '-extra-arg=-Wno-macro-redefined'
 
 set colorcolumn=120
 set textwidth=120
@@ -19,7 +28,11 @@ autocmd FileType xml setlocal shiftwidth=4 noexpandtab
 
 let g:ale_fix_on_save = 1
 
+function! s:configure_format_on_save() abort
+  let b:ale_fix_on_save = expand('%:p') =~# '/src/maszyna/' ? 0 : 1
+endfunction
+
 augroup AleFixOnSaveMaszyna
   autocmd!
-  autocmd BufRead,BufNewFile src/maszyna/* let g:ale_fix_on_save = 0
+  autocmd BufRead,BufNewFile *.c,*.h,*.cpp,*.hpp call s:configure_format_on_save()
 augroup END

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "llvm-vs-code-extensions.vscode-clangd",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,26 @@
   "C_Cpp_Runner.showCompilationTime": false,
   "C_Cpp_Runner.useLinkTimeOptimization": false,
   "C_Cpp_Runner.msvcSecureNoWarnings": false,
+  "C_Cpp.intelliSenseEngine": "disabled",
+  "C_Cpp.codeAnalysis.clangTidy.enabled": false,
+  "clangd.arguments": [
+    "--compile-commands-dir=${workspaceFolder}",
+    "--clang-tidy",
+    "--header-insertion=never",
+    "--fallback-style=none"
+  ],
+  "clang-format.style": "file",
+  "editor.rulers": [
+    120
+  ],
   "cmake.ignoreCMakeListsMissing": true,
-  "cmake.configureOnOpen": false
+  "cmake.configureOnOpen": false,
+  "[c]": {
+    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+    "editor.formatOnSave": true
+  },
+  "[cpp]": {
+    "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+    "editor.formatOnSave": true
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,150 @@
             "group": "build",
             "type": "shell",
             "command": "make"
+        },
+        {
+            "label": "configure clang-tidy database",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "cmake configure clang-tidy database",
+                "generate clang-tidy bindings"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "cmake configure clang-tidy database",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--log-level=ERROR",
+                "-S",
+                "${workspaceFolder}",
+                "-B",
+                "${workspaceFolder}/build-clang-tidy",
+                "-DCMAKE_CXX_COMPILER=clang++",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "generate clang-tidy bindings",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/build-clang-tidy",
+                "--target",
+                "generate_bindings"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "style-check current file",
+            "group": "test",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "clang-format check current file",
+                "clang-tidy current file"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "style-fix current file",
+            "group": "test",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "clang-format fix current file",
+                "clang-tidy fix current file",
+                "clang-format fix current file"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "clang-format check current file",
+            "group": "test",
+            "type": "shell",
+            "command": "clang-format",
+            "args": [
+                "--dry-run",
+                "--Werror",
+                "--style=file",
+                "${file}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "clang-format fix current file",
+            "group": "test",
+            "type": "shell",
+            "command": "clang-format",
+            "args": [
+                "-i",
+                "--style=file",
+                "${file}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "clang-tidy current file",
+            "group": "test",
+            "type": "shell",
+            "command": "clang-tidy",
+            "dependsOn": [
+                "configure clang-tidy database"
+            ],
+            "args": [
+                "--quiet",
+                "-p",
+                "${workspaceFolder}/build-clang-tidy",
+                "-extra-arg=-std=c++17",
+                "-extra-arg=-I${workspaceFolder}/src",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/include",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/gen/include",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/gdextension",
+                "-extra-arg=-Wno-macro-redefined",
+                "-line-filter=[{\"name\":\"${relativeFile}\"}]",
+                "${relativeFile}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "clang-tidy fix current file",
+            "group": "test",
+            "type": "shell",
+            "command": "clang-tidy",
+            "dependsOn": [
+                "configure clang-tidy database"
+            ],
+            "args": [
+                "--fix",
+                "--fix-errors",
+                "--quiet",
+                "-p",
+                "${workspaceFolder}/build-clang-tidy",
+                "-extra-arg=-std=c++17",
+                "-extra-arg=-I${workspaceFolder}/src",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/include",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/gen/include",
+                "-extra-arg=-I${workspaceFolder}/godot-cpp/gdextension",
+                "-extra-arg=-Wno-macro-redefined",
+                "-warnings-as-errors=-*",
+                "-line-filter=[{\"name\":\"${relativeFile}\"}]",
+                "${relativeFile}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
         }
     ]
 }

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ $(CLANG_TIDY_BUILD_DIR)/compile_commands.json:
 
 
 style-check: $(CLANG_TIDY_BUILD_DIR)/compile_commands.json
-	@scripts/style-check
+	@scripts/style-check $(STYLE_FILE)
 
 
 style-fix: $(CLANG_TIDY_BUILD_DIR)/compile_commands.json
-	@scripts/style-fix
+	@scripts/style-fix $(STYLE_FILE)
 
 docker-build-tests:
 	docker build -t godot-tests .

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: docs compile watch-and-compile docs-server docs-install cleanup run-clang-tidy run-clang-tidy-fix
+.PHONY: docs compile watch-and-compile docs-server docs-install cleanup style-check style-fix
 .DEFAULT_GOAL = compile-debug
 
 GITREV=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/[^A-Za-z0-9]//g')
 DATE=$(shell date +"%Y%m%d")
 CMAKE_BUILD_JOBS=$(shell cores=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1); if [ "$$cores" -gt 2 ]; then echo $$((cores - 2)); else echo 1; fi)
+CLANG_TIDY_BUILD_DIR=build-clang-tidy
 LIBMASZYNA_DEBUG:=""
 
 #Helper for CLion so it would see generated bindings
@@ -107,20 +108,17 @@ watch-and-compile:
 	sh scripts/autocompile.sh
 
 
-run-clang-tidy:
-	scons compiledb && \
-		find src/ \( -name "*.cpp" -or -name "*.hpp" \) \
-			-not -path "src/maszyna/*"\
-			-not -path "src/gen/*"\
-			-exec clang-tidy --fix-notes --quiet -p . {} +
+$(CLANG_TIDY_BUILD_DIR)/compile_commands.json:
+	@echo "Style: configuring clang-tidy database..." && \
+	cmake --log-level=ERROR -S . -B $(CLANG_TIDY_BUILD_DIR) -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 
-run-clang-tidy-fix:
-	scons compiledb && \
-		find src/ \( -name "*.cpp" -or -name "*.hpp" \) \
-			-not -path "src/maszyna/*"\
-			-not -path "src/gen/*"\
-			-exec clang-tidy --fix --fix-errors --quiet -p . {} +
+style-check: $(CLANG_TIDY_BUILD_DIR)/compile_commands.json
+	@scripts/style-check
+
+
+style-fix: $(CLANG_TIDY_BUILD_DIR)/compile_commands.json
+	@scripts/style-fix
 
 docker-build-tests:
 	docker build -t godot-tests .

--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ If you have found any bug, have a suggestion or want to join us - feel free to o
 
 ### Code Quality
 
+#### Formatting and style
+
+Before opening a pull request, check formatting and clang-tidy issues:
+
+```bash
+make style-check
+```
+
+To apply automatic formatting and clang-tidy fixes:
+
+```bash
+make style-fix
+```
+
+Both targets use the repository `.clang-format` and `.clang-tidy` configuration. They skip legacy/generated code under `src/maszyna` and `src/gen`.
+
+To check or fix a single file, use `./scripts/style-check <path>` and `./scripts/style-fix <path>`.
+
 #### CI
 Clang-tidy checks are performed on CI. Those will fail automatically and publish results if any warning/error is found
 

--- a/scripts/style-check
+++ b/scripts/style-check
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLANG_TIDY_BUILD_DIR="${ROOT_DIR}/build-clang-tidy"
+CLANG_TIDY_EXTRA_ARGS=(
+    -extra-arg=-std=c++17
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/gen/include"
+    -extra-arg=-Wno-macro-redefined
+)
+
+usage() {
+    echo "Usage: scripts/style-check [path/to/file]" >&2
+}
+
+ensure_compile_commands() {
+    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ]; then
+        echo "Style: configuring clang-tidy database..."
+        cmake --log-level=ERROR -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    fi
+}
+
+is_supported_format_file() {
+    [[ "$1" == *.cpp || "$1" == *.hpp || "$1" == *.h ]]
+}
+
+is_supported_tidy_file() {
+    [[ "$1" == *.cpp || "$1" == *.cc || "$1" == *.cxx || "$1" == *.c ]]
+}
+
+is_excluded_file() {
+    [[ "$1" == src/maszyna/* || "$1" == src/gen/* ]]
+}
+
+resolve_target_file() {
+    local file="$1"
+
+    if [ ! -f "${ROOT_DIR}/${file}" ] && [ -f "${file}" ]; then
+        file="$(realpath --relative-to="${ROOT_DIR}" "${file}")"
+    fi
+
+    if [ ! -f "${ROOT_DIR}/${file}" ]; then
+        echo "Style check: file not found: ${file}" >&2
+        exit 1
+    fi
+
+    if is_excluded_file "${file}"; then
+        echo "Style check: file is excluded from style checks: ${file}" >&2
+        exit 1
+    fi
+
+    if ! is_supported_format_file "${file}" && ! is_supported_tidy_file "${file}"; then
+        echo "Style check: unsupported file type: ${file}" >&2
+        exit 1
+    fi
+
+    echo "${file}"
+}
+
+run_clang_format() {
+    if [ "$#" -eq 0 ]; then
+        find "${ROOT_DIR}/src" \( -name "*.cpp" -or -name "*.hpp" -or -name "*.h" \) \
+            -not -path "${ROOT_DIR}/src/maszyna/*" \
+            -not -path "${ROOT_DIR}/src/gen/*" \
+            -exec clang-format --dry-run --Werror --style=file {} +
+    elif is_supported_format_file "$1"; then
+        clang-format --dry-run --Werror --style=file "${ROOT_DIR}/$1"
+    fi
+}
+
+run_clang_tidy() {
+    local files=()
+
+    if [ "$#" -eq 0 ]; then
+        while IFS= read -r file; do
+            files+=("${file#${ROOT_DIR}/}")
+        done < <(
+            find "${ROOT_DIR}/src" \( -name "*.cpp" -or -name "*.cc" -or -name "*.cxx" -or -name "*.c" \) \
+                -not -path "${ROOT_DIR}/src/maszyna/*" \
+                -not -path "${ROOT_DIR}/src/gen/*"
+        )
+    elif is_supported_tidy_file "$1"; then
+        files=("$1")
+    fi
+
+    for file in "${files[@]}"; do
+        (
+            cd "${ROOT_DIR}"
+            clang-tidy --quiet -p "${CLANG_TIDY_BUILD_DIR}" "${CLANG_TIDY_EXTRA_ARGS[@]}" \
+                -line-filter="[{\"name\":\"${file}\"}]" "${file}"
+        )
+    done
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 1
+fi
+
+target_file=""
+if [ "$#" -eq 1 ]; then
+    target_file="$(resolve_target_file "$1")"
+fi
+
+ensure_compile_commands
+
+echo "Style check: checking clang-format..."
+if [ -n "${target_file}" ]; then
+    run_clang_format "${target_file}"
+else
+    run_clang_format
+fi
+
+echo "Style check: checking clang-tidy..."
+if [ -n "${target_file}" ]; then
+    run_clang_tidy "${target_file}"
+else
+    run_clang_tidy
+fi
+
+echo "Style check: OK"

--- a/scripts/style-check
+++ b/scripts/style-check
@@ -5,7 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLANG_TIDY_BUILD_DIR="${ROOT_DIR}/build-clang-tidy"
 CLANG_TIDY_EXTRA_ARGS=(
     -extra-arg=-std=c++17
+    -extra-arg=-I"${ROOT_DIR}/src"
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/include"
     -extra-arg=-I"${ROOT_DIR}/godot-cpp/gen/include"
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/gdextension"
     -extra-arg=-Wno-macro-redefined
 )
 
@@ -14,12 +17,14 @@ usage() {
 }
 
 ensure_compile_commands() {
-    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ]; then
+    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ] || \
+        [ ! -f "${CLANG_TIDY_BUILD_DIR}/godot-cpp/gen/include/godot_cpp/classes/engine.hpp" ]; then
         echo "Style: configuring clang-tidy database..."
         cmake --log-level=ERROR -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        cmake --build "${CLANG_TIDY_BUILD_DIR}" --target generate_bindings
     fi
 }
 

--- a/scripts/style-fix
+++ b/scripts/style-fix
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLANG_TIDY_BUILD_DIR="${ROOT_DIR}/build-clang-tidy"
+CLANG_TIDY_EXTRA_ARGS=(
+    -extra-arg=-std=c++17
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/gen/include"
+    -extra-arg=-Wno-macro-redefined
+)
+
+usage() {
+    echo "Usage: scripts/style-fix [path/to/file]" >&2
+}
+
+ensure_compile_commands() {
+    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ]; then
+        echo "Style: configuring clang-tidy database..."
+        cmake --log-level=ERROR -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    fi
+}
+
+is_supported_format_file() {
+    [[ "$1" == *.cpp || "$1" == *.hpp || "$1" == *.h ]]
+}
+
+is_supported_tidy_file() {
+    [[ "$1" == *.cpp || "$1" == *.cc || "$1" == *.cxx || "$1" == *.c ]]
+}
+
+is_excluded_file() {
+    [[ "$1" == src/maszyna/* || "$1" == src/gen/* ]]
+}
+
+resolve_target_file() {
+    local file="$1"
+
+    if [ ! -f "${ROOT_DIR}/${file}" ] && [ -f "${file}" ]; then
+        file="$(realpath --relative-to="${ROOT_DIR}" "${file}")"
+    fi
+
+    if [ ! -f "${ROOT_DIR}/${file}" ]; then
+        echo "Style fix: file not found: ${file}" >&2
+        exit 1
+    fi
+
+    if is_excluded_file "${file}"; then
+        echo "Style fix: file is excluded from style checks: ${file}" >&2
+        exit 1
+    fi
+
+    if ! is_supported_format_file "${file}" && ! is_supported_tidy_file "${file}"; then
+        echo "Style fix: unsupported file type: ${file}" >&2
+        exit 1
+    fi
+
+    echo "${file}"
+}
+
+run_clang_format() {
+    if [ "$#" -eq 0 ]; then
+        find "${ROOT_DIR}/src" \( -name "*.cpp" -or -name "*.hpp" -or -name "*.h" \) \
+            -not -path "${ROOT_DIR}/src/maszyna/*" \
+            -not -path "${ROOT_DIR}/src/gen/*" \
+            -exec clang-format -i --style=file {} +
+    elif is_supported_format_file "$1"; then
+        clang-format -i --style=file "${ROOT_DIR}/$1"
+    fi
+}
+
+run_clang_tidy() {
+    local files=()
+
+    if [ "$#" -eq 0 ]; then
+        while IFS= read -r file; do
+            files+=("${file#${ROOT_DIR}/}")
+        done < <(
+            find "${ROOT_DIR}/src" \( -name "*.cpp" -or -name "*.cc" -or -name "*.cxx" -or -name "*.c" \) \
+                -not -path "${ROOT_DIR}/src/maszyna/*" \
+                -not -path "${ROOT_DIR}/src/gen/*"
+        )
+    elif is_supported_tidy_file "$1"; then
+        files=("$1")
+    fi
+
+    for file in "${files[@]}"; do
+        (
+            cd "${ROOT_DIR}"
+            clang-tidy --fix --fix-errors --quiet -p "${CLANG_TIDY_BUILD_DIR}" "${CLANG_TIDY_EXTRA_ARGS[@]}" \
+                -warnings-as-errors=-* \
+                -line-filter="[{\"name\":\"${file}\"}]" "${file}"
+        )
+    done
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 1
+fi
+
+target_file=""
+if [ "$#" -eq 1 ]; then
+    target_file="$(resolve_target_file "$1")"
+fi
+
+ensure_compile_commands
+
+echo "Style fix: running clang-format..."
+if [ -n "${target_file}" ]; then
+    run_clang_format "${target_file}"
+else
+    run_clang_format
+fi
+
+echo "Style fix: running clang-tidy fixes..."
+if [ -n "${target_file}" ]; then
+    run_clang_tidy "${target_file}"
+else
+    run_clang_tidy
+fi
+
+echo "Style fix: running clang-format after fixes..."
+if [ -n "${target_file}" ]; then
+    run_clang_format "${target_file}"
+else
+    run_clang_format
+fi
+
+echo "Style fix: OK"

--- a/scripts/style-fix
+++ b/scripts/style-fix
@@ -5,7 +5,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLANG_TIDY_BUILD_DIR="${ROOT_DIR}/build-clang-tidy"
 CLANG_TIDY_EXTRA_ARGS=(
     -extra-arg=-std=c++17
+    -extra-arg=-I"${ROOT_DIR}/src"
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/include"
     -extra-arg=-I"${ROOT_DIR}/godot-cpp/gen/include"
+    -extra-arg=-I"${ROOT_DIR}/godot-cpp/gdextension"
     -extra-arg=-Wno-macro-redefined
 )
 
@@ -14,12 +17,14 @@ usage() {
 }
 
 ensure_compile_commands() {
-    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ]; then
+    if [ ! -f "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ] || \
+        [ ! -f "${CLANG_TIDY_BUILD_DIR}/godot-cpp/gen/include/godot_cpp/classes/engine.hpp" ]; then
         echo "Style: configuring clang-tidy database..."
         cmake --log-level=ERROR -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        cmake --build "${CLANG_TIDY_BUILD_DIR}" --target generate_bindings
     fi
 }
 

--- a/src/maszyna/.clang-tidy
+++ b/src/maszyna/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: '-*,llvm-twine-local'
+WarningsAsErrors: ''
+HeaderFilterRegex: '$^'


### PR DESCRIPTION
Solves #195 

----

#177 introduces important changes to the code style and clang tidy.
We need a tool which will automatically format files in this style to avoid PR/diff mess.

This is a continuation of #177 