### PR TITLE
Potential segfaults fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Custom nodes and Godot Editor:
 
 * place editor related code in addons/libmaszyna/editor
 * use libmaszyna.gd just for bootstraping and proxying to editor plugins
+* make sure C++ singletons never inherit from RefCounted
 
 Documentation:
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -62,3 +62,28 @@ Always use `static_cast<type>`, don't use C-style cast
 ### Logging
 For dev logging, use and only Godot's built-in methods.  
 For in-game logging, use `GameLog` but be aware that it'll only post log messages to the Dev console or anything else connected to it's `log_updated` signal. It won't print logs to the Godot's console
+
+## C++ notes
+
+### Singletons C++
+
+* Never inherit from RefCounted (use plain `Object` as a base)
+* Register and de-register signletons in a proper order (check dependencies)
+* De-registering sequence should follow the schema:
+  - call `Engine::unregister_singleton()` with checking `Engine::has_singleton()`
+  - call `memdelete()` if pointer is not nullptr, then assign nullptr to the pointer
+  - double check order of deallocation singletons
+* `Engine::get_singleton()->get_singleton("<name>")` and/or `CustomSingleton::get_instance()` does not guarantee
+  a valid instance / pointer. Always check that the singleton pointer is not `nullptr`.
+
+### Pointers, Refs and RefCounted objects
+
+* Prefer Refs instead of raw pointers, if applicable
+* Do not mix `Ref` with `memnew()` / `memdelete()`
+* Instantiate Refs in the heap:
+  ```
+  SomeRefCountedObject obj;
+  obj.instantiate();
+  ```
+* Avoid circular dependencies between Refs - they may cause infinite lifecycle and memory leaks
+* Use raw pointers to avoid circular dependencies

--- a/src/core/GameLog.hpp
+++ b/src/core/GameLog.hpp
@@ -28,8 +28,8 @@
 
 namespace godot {
 
-    class GameLog : public RefCounted {
-            GDCLASS(GameLog, RefCounted);
+    class GameLog : public Object {
+            GDCLASS(GameLog, Object);
 
         public:
             static const char *LOG_UPDATED_SIGNAL;

--- a/src/core/TrainSystem.hpp
+++ b/src/core/TrainSystem.hpp
@@ -11,8 +11,8 @@ namespace godot {
 
     class TrainController;
 
-    class TrainSystem : public RefCounted {
-            GDCLASS(TrainSystem, RefCounted);
+    class TrainSystem : public Object {
+            GDCLASS(TrainSystem, Object);
 
         private:
             std::map<String, TrainController *> trains;

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -34,10 +34,11 @@ TrainSystem *train_system_singleton = nullptr;
 GameLog *game_log_singleton = nullptr;
 
 void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
-    UtilityFunctions::print("Initializing libmaszyna module on level " + String::num(p_level) + "...");;
+    UtilityFunctions::print("Initializing libmaszyna module on level " + String::num(p_level) + "...");
+    ;
 
     if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-//         GDREGISTER_CLASS(DieselEngineMasterControllerPowerItemEditor);
+        //         GDREGISTER_CLASS(DieselEngineMasterControllerPowerItemEditor);
     }
 
     if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -75,17 +76,29 @@ void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
-    UtilityFunctions::print("De-initializing libmaszyna module on level " + String::num(p_level) + "...");;
+    UtilityFunctions::print("De-initializing libmaszyna module on level " + String::num(p_level) + "...");
+    ;
 
     if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
         return;
     }
 
-    if (train_system_singleton != nullptr) {
+    if (Engine::get_singleton()->has_singleton("TrainSystem")) {
         Engine::get_singleton()->unregister_singleton("TrainSystem");
+    }
+
+    if (Engine::get_singleton()->has_singleton("GameLog")) {
         Engine::get_singleton()->unregister_singleton("GameLog");
-        // memdelete(train_system_singleton);
-        // train_system_singleton = nullptr;
+    }
+
+    if (train_system_singleton != nullptr) {
+        memdelete(train_system_singleton);
+        train_system_singleton = nullptr;
+    }
+
+    if (game_log_singleton != nullptr) {
+        memdelete(game_log_singleton);
+        game_log_singleton = nullptr;
     }
 }
 


### PR DESCRIPTION
The current implementation can cause random crashes and segfaults during hot reloading the plugin. 

This commit cleans up module initialization and de-initialization by removing RefCounted inheritance from singletons and by adding unregistering and freeing memory using appropriate conditions and ordering.