### PR TITLE
(#242) Improve Maszyna Parser

### DIFF
--- a/src/parsers/maszyna_parser.cpp
+++ b/src/parsers/maszyna_parser.cpp
@@ -2,32 +2,51 @@
 
 namespace godot {
     void MaszynaParser::_bind_methods() {
-        ClassDB::bind_method(D_METHOD("initialize", "buffer"), &MaszynaParser::initialize);
+        ClassDB::bind_method(
+                D_METHOD("initialize", "buffer", "default_stop"), &MaszynaParser::initialize, DEFVAL(Array()));
         ClassDB::bind_method(D_METHOD("get8"), &MaszynaParser::get8);
         ClassDB::bind_method(D_METHOD("get_line"), &MaszynaParser::get_line);
         ClassDB::bind_method(D_METHOD("eof_reached"), &MaszynaParser::eof_reached);
         ClassDB::bind_method(D_METHOD("register_handler", "token", "callback"), &MaszynaParser::register_handler);
+        ClassDB::bind_method(D_METHOD("unregister_handler", "token"), &MaszynaParser::unregister_handler);
         ClassDB::bind_method(D_METHOD("as_bool", "token"), &MaszynaParser::as_bool);
         ClassDB::bind_method(D_METHOD("as_vector3", "tokens"), &MaszynaParser::as_vector3);
-        ClassDB::bind_method(D_METHOD("get_tokens", "num", "stop"), &MaszynaParser::get_tokens);
-        ClassDB::bind_method(D_METHOD("next_token", "stop"), &MaszynaParser::next_token);
-        ClassDB::bind_method(D_METHOD("next_vector3", "stop"), &MaszynaParser::next_vector3);
-        ClassDB::bind_method(D_METHOD("get_tokens_until", "token", "stop"), &MaszynaParser::get_tokens_until);
+        ClassDB::bind_method(D_METHOD("get_tokens", "num", "stops"), &MaszynaParser::get_tokens, DEFVAL(Array()));
+        ClassDB::bind_method(D_METHOD("next_token", "stops"), &MaszynaParser::next_token, DEFVAL(Array()));
+        ClassDB::bind_method(D_METHOD("next_vector3", "stops"), &MaszynaParser::next_vector3, DEFVAL(Array()));
+        ClassDB::bind_method(
+                D_METHOD("get_tokens_until", "token", "stops"), &MaszynaParser::get_tokens_until, DEFVAL(Array()));
         ClassDB::bind_method(D_METHOD("parse"), &MaszynaParser::parse);
         ClassDB::bind_method(D_METHOD("get_parsed_metadata"), &MaszynaParser::get_parsed_metadata);
         ClassDB::bind_method(D_METHOD("push_metadata"), &MaszynaParser::push_metadata);
         ClassDB::bind_method(D_METHOD("pop_metadata"), &MaszynaParser::pop_metadata);
         ClassDB::bind_method(D_METHOD("clear_metadata"), &MaszynaParser::clear_metadata);
+        ClassDB::bind_method(D_METHOD("set_parameters"), &MaszynaParser::set_parameters);
     }
 
     MaszynaParser::MaszynaParser() {
-        meta.emplace_back();
+        default_stop_chars = Array::make(" ", "\t", "\n", "\r", ";");
+        meta.push_back(Dictionary());
     }
 
-    void MaszynaParser::initialize(const PackedByteArray &p_buffer) {
+    Array MaszynaParser::get_stops(const Array &p_stops) const {
+        if (!p_stops.is_empty()) {
+            return p_stops;
+        }
+        return default_stop_chars;
+    }
+
+    void MaszynaParser::set_parameters(const Dictionary &p_parameters) {
+        parameters = p_parameters;
+    }
+
+    void MaszynaParser::initialize(const PackedByteArray &p_buffer, const Array &p_default_stop_chars) {
         this->buffer = p_buffer;
         length = static_cast<int>(p_buffer.size());
         cursor = 0;
+        if (!p_default_stop_chars.is_empty()) {
+            default_stop_chars = p_default_stop_chars;
+        }
     }
 
     int MaszynaParser::get8() {
@@ -41,10 +60,10 @@ namespace godot {
         PackedByteArray subbuf;
         while (!eof_reached()) {
             const int c = get8();
-            if (c == 10 || c == 13) {
+            if (c == -1 || c == 10 || c == 13) {
                 break;
             }
-            subbuf.append(c);
+            subbuf.append(static_cast<uint8_t>(c));
         }
         return subbuf.get_string_from_utf8();
     }
@@ -57,16 +76,24 @@ namespace godot {
         handlers[p_token] = p_callback;
     }
 
+    void MaszynaParser::unregister_handler(const String &p_token) {
+        handlers.erase(p_token);
+    }
+
     bool MaszynaParser::as_bool(const String &p_token) {
         const String lower = p_token.to_lower();
         return lower == "yes" || lower == "on" || lower == "1" || lower == "true" || lower == "vis";
     }
 
     Vector3 MaszynaParser::as_vector3(const Array &p_tokens) {
+        if (p_tokens.size() < 3) {
+            return Vector3();
+        }
         return Vector3(p_tokens[0], p_tokens[1], p_tokens[2]);
     }
 
-    Array MaszynaParser::get_tokens(const int p_num, const Array &p_stop) {
+    Array MaszynaParser::get_tokens(const int p_num, const Array &p_stops) {
+        const Array stop_chars = get_stops(p_stops);
         Array tokens;
         bool maybe_comment = false;
         bool maybe_endcomment = false;
@@ -75,14 +102,22 @@ namespace godot {
             String token = "";
 
             while (!eof_reached()) {
-                char c = static_cast<char>(get8());
+                int c_int = get8();
+                if (c_int == -1) {
+                    break;
+                }
+                char c = static_cast<char>(c_int);
                 bool skip = false;
 
                 if (c == '/') {
                     if (maybe_comment) {
+                        maybe_comment = false;
                         // Line comment detected
-                        while (!eof_reached() && c != '\n' && c != '\r') {
-                            c = static_cast<char>(get8());
+                        while (!eof_reached()) {
+                            int next_c = get8();
+                            if (next_c == -1 || next_c == '\n' || next_c == '\r') {
+                                break;
+                            }
                         }
                         skip = true;
                     } else {
@@ -95,10 +130,14 @@ namespace godot {
                         maybe_endcomment = false;
                         // Block comment detected
                         while (!eof_reached()) {
-                            c = static_cast<char>(get8());
-                            if (c == '*') {
+                            int next_c = get8();
+                            if (next_c == -1) {
+                                break;
+                            }
+                            char bc = static_cast<char>(next_c);
+                            if (bc == '*') {
                                 maybe_endcomment = true;
-                            } else if (c == '/' && maybe_endcomment) {
+                            } else if (bc == '/' && maybe_endcomment) {
                                 break;
                             } else {
                                 maybe_endcomment = false;
@@ -113,7 +152,7 @@ namespace godot {
                     token += '/';
                 }
 
-                if (skip || p_stop.has(String::chr(c))) {
+                if (skip || stop_chars.has(String::chr(c))) {
                     break;
                 }
 
@@ -136,21 +175,20 @@ namespace godot {
         return tokens;
     }
 
-    String MaszynaParser::next_token(const Array &p_stop = Array::make(" ", '\t', '\n', '\r', ';')) {
-        Array tokens = get_tokens(1, p_stop);
+    String MaszynaParser::next_token(const Array &p_stops) {
+        Array tokens = get_tokens(1, p_stops);
         return tokens.size() > 0 ? tokens[0] : "";
     }
 
-    Vector3 MaszynaParser::next_vector3(const Array &p_stop) {
-        const Array tokens = get_tokens(3, p_stop);
+    Vector3 MaszynaParser::next_vector3(const Array &p_stops) {
+        const Array tokens = get_tokens(3, p_stops);
         return as_vector3(tokens);
     }
 
-    Array MaszynaParser::get_tokens_until(
-            const String &p_token, const Array &p_stop = Array::make(" ", '\t', '\n', '\r', ';')) {
+    Array MaszynaParser::get_tokens_until(const String &p_token, const Array &p_stops) {
         Array tokens;
         while (!eof_reached()) {
-            if (String upcoming_token = next_token(p_stop); !upcoming_token.is_empty()) {
+            if (String upcoming_token = next_token(p_stops); !upcoming_token.is_empty()) {
                 tokens.append(upcoming_token);
                 if (upcoming_token == p_token) {
                     break;
@@ -167,8 +205,12 @@ namespace godot {
         while (!eof_reached()) {
             if (String token = next_token(); handlers.has(token)) {
                 if (Callable callback = handlers[token]; callback.is_valid()) {
-                    if (Array parsed = callback.call(); parsed.size() > 0) {
-                        result.append_array(parsed);
+                    Variant parsed_v = callback.call(this);
+                    if (parsed_v.get_type() == Variant::ARRAY) {
+                        Array parsed = parsed_v;
+                        if (parsed.size() > 0) {
+                            result.append_array(parsed);
+                        }
                     }
                 }
             }
@@ -178,21 +220,27 @@ namespace godot {
     }
 
     Dictionary MaszynaParser::get_parsed_metadata() {
-        return meta.front();
+        if (meta.is_empty()) {
+            return Dictionary();
+        }
+        return meta[0];
     }
 
     void MaszynaParser::push_metadata() {
-        meta.insert(meta.begin(), Dictionary());
+        meta.push_front(Dictionary());
     }
 
     Dictionary MaszynaParser::pop_metadata() {
-        Dictionary top = meta.front();
-        meta.erase(meta.begin());
+        if (meta.is_empty()) {
+            return Dictionary();
+        }
+        Dictionary top = meta[0];
+        meta.pop_front();
         return top;
     }
 
     void MaszynaParser::clear_metadata() {
         meta.clear();
-        meta.emplace_back();
+        meta.push_back(Dictionary());
     }
 } // namespace godot

--- a/src/parsers/maszyna_parser.hpp
+++ b/src/parsers/maszyna_parser.hpp
@@ -1,42 +1,47 @@
 #pragma once
 
-#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/typed_array.hpp>
 #include <godot_cpp/variant/vector3.hpp>
 #include <vector>
 
 namespace godot {
-    class MaszynaParser : public Object {
-            GDCLASS(MaszynaParser, Object);
+    class MaszynaParser : public RefCounted {
+            GDCLASS(MaszynaParser, RefCounted);
 
         private:
             PackedByteArray buffer;
             Dictionary handlers;
             int cursor = 0;
             int length = 0;
-            std::vector<Dictionary> meta;
+            TypedArray<Dictionary> meta;
+            Array default_stop_chars;
             Dictionary parameters;
+            Array get_stops(const Array &p_stops) const;
 
         protected:
             static void _bind_methods();
 
         public:
             MaszynaParser();
-            void initialize(const PackedByteArray &p_buffer);
+            void initialize(const PackedByteArray &p_buffer, const Array &p_default_stop_chars);
             // void _create_instance(const PackedByteArray &buffer);
             int get8();
             String get_line();
             bool eof_reached() const;
             void register_handler(const String &p_token, const Callable &p_callback);
+            void unregister_handler(const String &p_token);
+            void set_parameters(const Dictionary &p_parameters);
             bool as_bool(const String &p_token);
             Vector3 as_vector3(const Array &p_tokens);
-            Array get_tokens(int p_num, const Array &p_stop);
-            String next_token(const Array &p_stop);
-            Vector3 next_vector3(const Array &p_stop);
-            Array get_tokens_until(const String &p_token, const Array &p_stop);
+            Array get_tokens(int p_num, const Array &p_stops = Array());
+            String next_token(const Array &p_stops = Array());
+            Vector3 next_vector3(const Array &p_stops = Array());
+            Array get_tokens_until(const String &p_token, const Array &p_stops = Array());
             Array parse();
             Dictionary get_parsed_metadata();
             void push_metadata();


### PR DESCRIPTION
Fixes #242 

----

* replace std::vector with TypedArray
* add unregister_handler()
* fix incorrect parsing of inline commets something // coment
* introduce default stop chars and make stops optional in methods like get_tokens_until() or next_token()