### PR TITLE
Add `TrainPhysicsServer` implementation and register it as a singleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs compile watch-and-compile docs-server docs-install cleanup style-check style-fix
+.PHONY: docs watch-and-compile docs-server docs-install cleanup style-check style-fix
 .DEFAULT_GOAL = compile-debug
 
 GITREV=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/[^A-Za-z0-9]//g')
@@ -148,5 +148,5 @@ docker-run-tests: docker-build-tests
 	docker run --rm godot-tests
 
 
-run-tests: compile
+run-tests: compile-debug
 	godot --path demo --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests/ -gexit

--- a/addons/libmaszyna/maszyna_gut_test.gd
+++ b/addons/libmaszyna/maszyna_gut_test.gd
@@ -5,3 +5,13 @@ func wait_idle_frames(frames, message = ""):
     while frames > 0:
         await Engine.get_main_loop().process_frame
         frames -= 1
+
+# Train/mover config changes (train.battery_voltage = ..., send_command(...), etc.) are only
+# applied to the underlying TMoverParameters once per physics tick, inside
+# TrainPhysicsServer.step_physics() — never on the idle/render frame. Use this instead of
+# wait_idle_frames() whenever a test needs such a change to actually take effect and be reflected
+# in train.state before asserting on it.
+func wait_physics_frames(frames, message = ""):
+    while frames > 0:
+        await Engine.get_main_loop().physics_frame
+        frames -= 1

--- a/demo/tests/test_sm42_startup_sequence.gd
+++ b/demo/tests/test_sm42_startup_sequence.gd
@@ -5,9 +5,9 @@ var train: TrainController
 func before_each():
     train = load("res://tests/sm42_controller.tscn").instantiate()
     add_child(train)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     train.send_command("battery", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
 
 func after_each():
     remove_child(train)
@@ -15,12 +15,12 @@ func after_each():
 
 func test_successful_enabling_oil_pump():
     train.send_command("oil_pump", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_true(train.state["oil_pump_active"], "Oil pump should be active")
 
 func test_successful_enabling_fuel_pump():
     train.send_command("fuel_pump", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_true(train.state["fuel_pump_active"], "Fuel pump should be active")
 
 func test_successful_pumping_the_oil():
@@ -43,7 +43,7 @@ func test_successful_turning_engine_on():
 
 func test_successful_brake_releasing():
     train.send_command("brake_level_set_position", "drive")
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     train.send_command("brake_releaser", true)
     await wait_seconds(10)
     var value = train.state["brake_air_pressure"]

--- a/demo/tests/test_train_battery.gd
+++ b/demo/tests/test_train_battery.gd
@@ -22,13 +22,14 @@ func test_successful_battery_enabling():
 
 func test_not_enabling_battery_when_battery_voltage_is_zero():
     # This is a quite fun case: we're changing train's properties at runtime.
-    # To make sure the original Mover is updating, you must wait two IDLE frames or more.
+    # To make sure the original Mover is updating, you must wait two PHYSICS frames or more
+    # (config is only flushed into the Mover once per physics tick, in TrainPhysicsServer).
     # Alternatively you can call train.update_mover(), but this is an experimental method.
     #
     # This is not how tests should be written, but it shows how to handle similar cases.
 
     train.battery_voltage = 0.0
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
 
     train.send_command("battery", true)
     assert_false(train.state["battery_enabled"], "Battery should be disabled")

--- a/demo/tests/test_train_ep_fuse_switch.gd
+++ b/demo/tests/test_train_ep_fuse_switch.gd
@@ -7,7 +7,7 @@ func before_each():
     train.train_id = "TestTrain"
     train.battery_voltage = 110.0
     add_child(train)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
 
 func after_each():
     remove_child(train)
@@ -15,11 +15,11 @@ func after_each():
 
 func test_successful_ep_fuse_enabling():
     train.send_command("switch_ep_fuse", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     print(train.state)
     assert_true(train.state["dcemued/ep_fuse"], "EP Fuse should be enabled")
 
 func test_successful_ep_fuse_disabling():
     train.send_command("switch_ep_fuse", false)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_false(train.state["dcemued/ep_fuse"], "EP Fuse should be disabled")

--- a/demo/tests/test_train_spring_brake.gd
+++ b/demo/tests/test_train_spring_brake.gd
@@ -5,9 +5,9 @@ var train: TrainController
 func before_each():
     train = load("res://tests/sm42_controller.tscn").instantiate()
     add_child(train)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     train.send_command("battery", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
 
 func after_each():
     remove_child(train)
@@ -15,20 +15,20 @@ func after_each():
 
 func test_successful_activate_spring_brake():
     train.send_command("set_spring_brake_active", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_true(train.state["spring_brake/active"], "Spring brake should be active")
 
 func test_successful_deactivate_spring_brake():
     train.send_command("set_spring_brake_active", false)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_false(train.state["spring_brake/active"], "Spring brake should not be active")
 
 func test_successful_enable_spring_brake():
     train.send_command("set_spring_brake_enabled", true)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_true(train.state["spring_brake/shut_off"], "Spring brake should be enabled")
 
 func test_successful_disable_spring_brake():
     train.send_command("set_spring_brake_enabled", false)
-    await wait_idle_frames(2)
+    await wait_physics_frames(2)
     assert_false(train.state["spring_brake/shut_off"], "Spring brake should not be enabled")

--- a/doc_classes/E3DModel.xml
+++ b/doc_classes/E3DModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="E3DModel" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="E3DModel" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Resource representing a MaSzyna E3D model
 	</brief_description>

--- a/doc_classes/E3DModelLightDefinition.xml
+++ b/doc_classes/E3DModelLightDefinition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="E3DModelLightDefinition" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="E3DModelLightDefinition" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Describes a E3D model light
 	</brief_description>

--- a/doc_classes/E3DParser.xml
+++ b/doc_classes/E3DParser.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="E3DParser" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="E3DParser" inherits="Object" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Low-level parser for the MaSzyna E3D binary model format.
 	</brief_description>

--- a/doc_classes/E3DResourceFormatLoader.xml
+++ b/doc_classes/E3DResourceFormatLoader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="E3DResourceFormatLoader" inherits="ResourceFormatLoader" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="E3DResourceFormatLoader" inherits="ResourceFormatLoader" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Resource loader for MaSzyna [code].e3d[/code] model files.
 	</brief_description>

--- a/doc_classes/E3DSubModel.xml
+++ b/doc_classes/E3DSubModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="E3DSubModel" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="E3DSubModel" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Represents a single subcomponent of an E3D model, containing geometry and metadata.
 	</brief_description>

--- a/doc_classes/GameLog.xml
+++ b/doc_classes/GameLog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GameLog" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GameLog" inherits="Object" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Application-wide logger for general purpose. Use it to write messages to the game's debug console. For development-only logs, prefer Godot's built-in functions such as push_error(), push_warning(), print(), and print_rich().
 	</brief_description>

--- a/doc_classes/GenericTrainPart.xml
+++ b/doc_classes/GenericTrainPart.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GenericTrainPart" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GenericTrainPart" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Generic TrainPart
 	</brief_description>

--- a/doc_classes/LightListItem.xml
+++ b/doc_classes/LightListItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LightListItem" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="LightListItem" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Item for light selector indicating which lights it should light up
 	</brief_description>

--- a/doc_classes/LoadListItem.xml
+++ b/doc_classes/LoadListItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LoadListItem" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="LoadListItem" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Resource defining load parameters for train cars.
 	</brief_description>

--- a/doc_classes/MaszynaParser.xml
+++ b/doc_classes/MaszynaParser.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="MaszynaParser" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="MaszynaParser" inherits="RefCounted" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Parser for .e3d MaSzyna files. Reads meshes and creates them in Godot.
 	</brief_description>
@@ -119,7 +119,7 @@
 		</method>
 		<method name="set_parameters">
 			<return type="void" />
-			<param index="0" name="parameters" type="Dictionary" />
+			<param index="0" name="_unnamed_arg0" type="Dictionary" />
 			<description>
 				Sets custom parameters for the parser that can be used during the parsing process.
 			</description>

--- a/doc_classes/MotorParameter.xml
+++ b/doc_classes/MotorParameter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="MotorParameter" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="MotorParameter" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Defines motor parameters for a specific resistance position.
 	</brief_description>

--- a/doc_classes/OggVorbisFormatLoader.xml
+++ b/doc_classes/OggVorbisFormatLoader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OggVorbisFormatLoader" inherits="ResourceFormatLoader" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="OggVorbisFormatLoader" inherits="ResourceFormatLoader" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Resource loader for runtime [code].ogg[/code] audio files.
 	</brief_description>

--- a/doc_classes/ResourceCache.xml
+++ b/doc_classes/ResourceCache.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ResourceCache" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="ResourceCache" inherits="RefCounted" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Manages cached resources in [code]user://[/code] directory
 	</brief_description>

--- a/doc_classes/TrainBrake.xml
+++ b/doc_classes/TrainBrake.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainBrake" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainBrake" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Represents and configures the vehicle brake system and exposes controls to operate it.
 	</brief_description>

--- a/doc_classes/TrainBuffCoupl.xml
+++ b/doc_classes/TrainBuffCoupl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainBuffCoupl" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainBuffCoupl" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Handles train buffers and coupling mechanisms.
 	</brief_description>

--- a/doc_classes/TrainController.xml
+++ b/doc_classes/TrainController.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainController" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainController" inherits="Node" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Base train controller controlling all train systems
 	</brief_description>

--- a/doc_classes/TrainDieselElectricEngine.xml
+++ b/doc_classes/TrainDieselElectricEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainDieselElectricEngine" inherits="TrainDieselEngine" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainDieselElectricEngine" inherits="TrainDieselEngine" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc_classes/TrainDieselEngine.xml
+++ b/doc_classes/TrainDieselEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainDieselEngine" inherits="TrainEngine" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainDieselEngine" inherits="TrainEngine" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Diesel engine handler class. Used to check/set it's parameters
 	</brief_description>

--- a/doc_classes/TrainDoors.xml
+++ b/doc_classes/TrainDoors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainDoors" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainDoors" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		This class is eligible for managing door behavior as well as their low-circuit voltage, platforms, opening, closing and controlling
 	</brief_description>

--- a/doc_classes/TrainElectricEngine.xml
+++ b/doc_classes/TrainElectricEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainElectricEngine" inherits="TrainEngine" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainElectricEngine" inherits="TrainEngine" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Electric engine handler class. Used to check/set it's parameters
 	</brief_description>

--- a/doc_classes/TrainElectricSeriesEngine.xml
+++ b/doc_classes/TrainElectricSeriesEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainElectricSeriesEngine" inherits="TrainElectricEngine" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainElectricSeriesEngine" inherits="TrainElectricEngine" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Subclass of TrainElectricEngine. Adds additional parameters for more specific engines
 	</brief_description>

--- a/doc_classes/TrainElectroPneumaticDynamicBrake.xml
+++ b/doc_classes/TrainElectroPneumaticDynamicBrake.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainElectroPneumaticDynamicBrake" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainElectroPneumaticDynamicBrake" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Class used to handle Electro Pneumatic and Electro Dynamic brakes along with their parameters.
 	</brief_description>

--- a/doc_classes/TrainEngine.xml
+++ b/doc_classes/TrainEngine.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainEngine" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainEngine" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Core engine class. Contains most common things for all of available engine types
 	</brief_description>

--- a/doc_classes/TrainLighting.xml
+++ b/doc_classes/TrainLighting.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainLighting" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainLighting" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Class used for handling settings for headlight in front of both vehicle cabins
 	</brief_description>

--- a/doc_classes/TrainLoad.xml
+++ b/doc_classes/TrainLoad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainLoad" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainLoad" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		A class that manages cargo loading and unloading operations for train cars.
 	</brief_description>

--- a/doc_classes/TrainPart.xml
+++ b/doc_classes/TrainPart.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainPart" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainPart" inherits="Node" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Basic class of the train part.
 	</brief_description>

--- a/doc_classes/TrainPhysicsServer.xml
+++ b/doc_classes/TrainPhysicsServer.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TrainPhysicsServer" inherits="Object" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Server managing train physics execution.
+	</brief_description>
+	<description>
+		[TrainPhysicsServer] is a singleton responsible for centralized physics calculation of all registered trains ([TrainController]) and their parts ([TrainPart]). It internally uses a synchronization barrier, separating raw physics calculations from Godot API state updates. The server automatically connects to the Godot physics loop ([code]physics_frame[/code] signal) when the first train enters the scene.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="step_physics">
+			<return type="void" />
+			<param index="0" name="delta" type="float" />
+			<description>
+				Triggers a single physics calculation step with the given [param delta] time step. It is called automatically by the server on every Godot physics frame.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/TrainSecuritySystem.xml
+++ b/doc_classes/TrainSecuritySystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainSecuritySystem" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainSecuritySystem" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Class used to handle all security systems like CA/SHP and SIFA
 	</brief_description>

--- a/doc_classes/TrainSpringBrake.xml
+++ b/doc_classes/TrainSpringBrake.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainSpringBrake" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainSpringBrake" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Class that handles all spring-brake-related operations
 	</brief_description>

--- a/doc_classes/TrainSystem.xml
+++ b/doc_classes/TrainSystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainSystem" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainSystem" inherits="Object" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Handles trains registry and communication between trains and train systems
 	</brief_description>

--- a/doc_classes/TrainWheels.xml
+++ b/doc_classes/TrainWheels.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TrainWheels" inherits="TrainPart" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="TrainWheels" inherits="TrainPart" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Class used to configure wheel geometry and expose wheel-related runtime state.
 	</brief_description>

--- a/doc_classes/UserSettings.xml
+++ b/doc_classes/UserSettings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="UserSettings" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="UserSettings" inherits="Object" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Handles user settings in a centralized way.
 	</brief_description>

--- a/doc_classes/WWListItem.xml
+++ b/doc_classes/WWListItem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="WWListItem" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="WWListItem" inherits="Resource" api_type="extension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		This class stores the properties of a diesel engine for a specific resistance position on the controller in the driver's cabin, used when the locomotive has resistance start. Each instance of WWListItem represents a single resistance position.
 	</brief_description>

--- a/src/core/GenericTrainPart.cpp
+++ b/src/core/GenericTrainPart.cpp
@@ -19,12 +19,18 @@ namespace godot {
     Dictionary GenericTrainPart::_get_train_part_state() {
         return internal_state;
     };
-    void GenericTrainPart::_process_mover(const double p_delta) {
-        call("_process_train_part", p_delta);
-        // FIXME: this should not be called each frame, but only when state changes
-        internal_state = call("_get_train_part_state");
-        train_controller_node->get_state().merge(internal_state, true);
+    void GenericTrainPart::_process_mover_thread_safe(const double p_delta) {
+        last_delta = p_delta;
     };
+
+    void GenericTrainPart::_post_process_mover_sync() {
+        call("_process_train_part", last_delta);
+        internal_state = call("_get_train_part_state");
+        if (train_controller_node != nullptr) {
+            train_controller_node->get_state().merge(internal_state, true);
+        }
+    };
+
 
     TrainController *GenericTrainPart::get_train_controller_node() {
         return train_controller_node;

--- a/src/core/GenericTrainPart.hpp
+++ b/src/core/GenericTrainPart.hpp
@@ -10,6 +10,11 @@ namespace godot {
         private:
             static void _bind_methods();
             Dictionary internal_state;
+            // Captured by _process_mover_thread_safe() (real physics-tick delta from
+            // TrainPhysicsServer::step_physics()) and consumed by _post_process_mover_sync(), which
+            // runs afterwards in the same tick to forward it to the GDScript _process_train_part()
+            // virtual.
+            double last_delta = 0.0;
 
         protected:
             void _do_update_internal_mover(TMoverParameters *p_mover) override;
@@ -19,7 +24,8 @@ namespace godot {
 
         public:
             TrainController *get_train_controller_node();
-            void _process_mover(double p_delta) override;
+            void _process_mover_thread_safe(double p_delta) override;
+            void _post_process_mover_sync() override;
             virtual void _process_train_part(double p_delta);
             virtual Dictionary _get_train_part_state();
             Dictionary get_train_state();

--- a/src/core/TrainController.cpp
+++ b/src/core/TrainController.cpp
@@ -2,6 +2,7 @@
 #include "../core/TrainPart.hpp"
 #include "../core/TrainSystem.hpp"
 #include "../engines/TrainEngine.hpp"
+#include "../systems/TrainPhysicsServer.hpp"
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/gd_extension.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -110,21 +111,23 @@ namespace godot {
     }
 
     TMoverParameters *TrainController::get_mover() const {
-        return mover;
+        return TrainPhysicsServer::get_instance() != nullptr ? TrainPhysicsServer::get_instance()->get_mover(mover_rid)
+                                                               : nullptr;
     }
 
     void TrainController::initialize_mover() {
         const auto initial_vel = this->initial_velocity;
         const auto mover_type_name = std::string(type_name.utf8().ptr());
         const auto name = std::string(this->get_name().left(this->get_name().length()).utf8().ptr());
-        mover = std::make_unique<TMoverParameters>(initial_vel, mover_type_name, name, this->cabin_number).release();
+        mover_rid = TrainPhysicsServer::get_instance()->create_mover(initial_vel, mover_type_name, name, this->cabin_number);
+        TMoverParameters *mover = get_mover();
 
         dirty = true;
         dirty_prop = true;
         _update_mover_config_if_dirty();
 
         /* FIXME: CheckLocomotiveParameters should be called after (re)initialization */
-        mover->CheckLocomotiveParameters(true, 0); // FIXME: brakujace parametery
+        mover->CheckLocomotiveParameters(true, 0); // FIXME: missing parameters
 
         /* CheckLocomotiveParameters() will reset some parameters, so the changes
          * must be applied second time */
@@ -141,7 +144,7 @@ namespace godot {
         mover->CabActivisationAuto();
         mover->CabActivisation();
 
-        /* switch_physics() raczej trzeba zostawic */
+        /* switch_physics() probably needs to be left here */
         mover->switch_physics(true);
 
         DEBUG("[MaSzyna::TMoverParameters] Mover initialized successfully");
@@ -163,6 +166,9 @@ namespace godot {
         switch (p_what) {
             case NOTIFICATION_ENTER_TREE:
                 TrainSystem::get_instance()->register_train(train_id, this);
+                if (TrainPhysicsServer::get_instance() != nullptr) {
+                    TrainPhysicsServer::get_instance()->register_controller(this);
+                }
                 register_command("battery", Callable(this, "battery"));
                 register_command("main_controller_increase", Callable(this, "main_controller_increase"));
                 register_command("main_controller_decrease", Callable(this, "main_controller_decrease"));
@@ -184,6 +190,10 @@ namespace godot {
                 unregister_command("radio_channel_increase", Callable(this, "radio_channel_increase"));
                 unregister_command("radio_channel_decrease", Callable(this, "radio_channel_decrease"));
                 TrainSystem::get_instance()->unregister_train(train_id);
+                if (TrainPhysicsServer::get_instance() != nullptr) {
+                    TrainPhysicsServer::get_instance()->unregister_controller(this);
+                    TrainPhysicsServer::get_instance()->free_mover(mover_rid);
+                }
                 break;
             case NOTIFICATION_READY:
                 initialize_mover();
@@ -204,7 +214,7 @@ namespace godot {
             emit_signal(mover_config_changed_signal);
 
             dirty = false;
-            dirty_prop = true; // sforsowanie odswiezenia stanu lokalnych propsow
+            dirty_prop = true; // forcing refresh of local properties state
         }
 
         if (dirty_prop) {
@@ -213,7 +223,11 @@ namespace godot {
         }
     }
 
-    void TrainController::_process_mover(const double p_delta) {
+    void TrainController::_process_mover_thread_safe(const double p_delta) {
+        TMoverParameters *mover = get_mover();
+        if (mover == nullptr) {
+            return;
+        }
         TLocation mock_location;
         TRotation mock_rotation;
         mover->ComputeTotalForce(p_delta);
@@ -221,7 +235,9 @@ namespace godot {
         mover->ComputeMovement(
                 p_delta, p_delta, mover->RunningShape, mover->RunningTrack, mover->RunningTraction, mock_location,
                 mock_rotation);
+    }
 
+    void TrainController::_post_process_mover_sync() {
         _handle_mover_update();
     }
 
@@ -250,16 +266,6 @@ namespace godot {
         }
     }
 
-    void TrainController::_process(const double p_delta) {
-        /* nie daj borze w edytorze */
-        if (Engine::get_singleton()->is_editor_hint()) {
-            return;
-        }
-
-        _update_mover_config_if_dirty();
-        _process_mover(p_delta);
-    }
-
     void TrainController::_do_update_internal_mover(TMoverParameters *p_mover) const {
         p_mover->Mass = mass;
         p_mover->Power = power;
@@ -282,7 +288,7 @@ namespace godot {
             update_config(new_config);
 
             /* FIXME: CheckLocomotiveParameters should be called after (re)initialization */
-            mover->CheckLocomotiveParameters(true, 0); // FIXME: brakujace parametery
+            mover->CheckLocomotiveParameters(true, 0); // FIXME: missing parameters
         } else {
             UtilityFunctions::push_warning("TrainController::update_mover() failed: internal mover not initialized");
         }
@@ -359,25 +365,25 @@ namespace godot {
     }
 
     void TrainController::battery(const bool p_enabled) const {
-        mover->BatterySwitch(p_enabled);
+        get_mover()->BatterySwitch(p_enabled);
     }
 
     void TrainController::main_controller_increase(const int p_step) const {
         const int step = p_step > 0 ? p_step : 1;
-        mover->IncMainCtrl(step);
+        get_mover()->IncMainCtrl(step);
     }
 
     void TrainController::main_controller_decrease(const int p_step) const {
         const int step = p_step > 0 ? p_step : 1;
-        mover->DecMainCtrl(step);
+        get_mover()->DecMainCtrl(step);
     }
 
     void TrainController::direction_increase() const {
-        mover->DirectionForward();
+        get_mover()->DirectionForward();
     }
 
     void TrainController::direction_decrease() const {
-        mover->DirectionBackward();
+        get_mover()->DirectionBackward();
     }
 
     void TrainController::radio_channel_increase(const int p_step) {
@@ -395,6 +401,6 @@ namespace godot {
     }
 
     void TrainController::radio(const bool p_enabled) {
-        mover->Radio = p_enabled;
+        get_mover()->Radio = p_enabled;
     }
 } // namespace godot

--- a/src/core/TrainController.hpp
+++ b/src/core/TrainController.hpp
@@ -2,6 +2,7 @@
 #include "../maszyna/McZapkie/MOVER.h"
 #include "macros.hpp"
 #include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/variant/rid.hpp>
 
 
 namespace godot {
@@ -15,7 +16,9 @@ namespace godot {
     class TrainController : public Node {
             GDCLASS(TrainController, Node)
         private:
-            TMoverParameters *mover{};
+            // TMoverParameters is owned by TrainPhysicsServer (see create_mover()/free_mover()); this
+            // controller only ever holds a handle to it, resolved through the server on every access.
+            RID mover_rid;
             double initial_velocity = 0.0;
             int cabin_number = 0;
             void initialize_mover();
@@ -31,7 +34,6 @@ namespace godot {
             int prev_radio_channel = radio_channel;
 
             void _collect_train_parts(const Node *p_node, Vector<TrainPart *> &p_train_parts) {};
-            void _update_mover_config_if_dirty();
             void _handle_mover_update();
 
         protected:
@@ -40,14 +42,21 @@ namespace godot {
              * because the mover initialization and state sharing routines can be changed in the future. */
 
             Dictionary get_mover_state();
-            // TrainController mozna bedzie rozszerzac klasami pochodnymi i przeslaniac metody
+            // TrainController can be extended by derived classes and methods can be overridden
             void _do_update_internal_mover(TMoverParameters *p_mover) const;
             void _do_fetch_config_from_mover(const TMoverParameters *p_mover, Dictionary &p_config) const;
             void _do_fetch_state_from_mover(TMoverParameters *p_mover, Dictionary &p_state);
-            void _process_mover(double p_delta);
 
 
         public:
+            // Physics-tick-only lifecycle, driven exclusively by TrainPhysicsServer::step_physics()
+            // (never by Node's own _process()/_physics_process(), so nothing here can run at a
+            // different cadence than the simulation itself): flush any dirty config, then compute,
+            // then sync Godot-visible state.
+            void _update_mover_config_if_dirty();
+            void _process_mover_thread_safe(double p_delta);
+            void _post_process_mover_sync();
+
             enum TrainPowerSource {
                 POWER_SOURCE_NOT_DEFINED,
                 POWER_SOURCE_INTERNAL,
@@ -114,7 +123,6 @@ namespace godot {
 
             Dictionary get_config() const;
             void update_config(const Dictionary &p_config);
-            void _process(double p_delta) override;
             void _notification(int p_what);
             void send_command(
                     const StringName &p_command, const Variant &p_p1 = Variant(),

--- a/src/core/TrainPart.cpp
+++ b/src/core/TrainPart.cpp
@@ -1,3 +1,4 @@
+#include "../systems/TrainPhysicsServer.hpp"
 #include "./TrainSystem.hpp"
 #include "TrainController.hpp"
 #include "TrainPart.hpp"
@@ -68,6 +69,9 @@ namespace godot {
                                 String::num(con));
                     }
                 }
+                if (TrainPhysicsServer::get_instance() != nullptr) {
+                    TrainPhysicsServer::get_instance()->register_part(this);
+                }
                 if (enabled) {
                     _register_commands();
                     _commands_registered = true;
@@ -81,6 +85,9 @@ namespace godot {
                 if (train_controller_node != nullptr) {
                     train_controller_node->disconnect(
                             TrainController::mover_config_changed_signal, Callable(this, "update_mover"));
+                }
+                if (TrainPhysicsServer::get_instance() != nullptr) {
+                    TrainPhysicsServer::get_instance()->unregister_part(this);
                 }
                 train_controller_node = nullptr;
             } break;
@@ -121,19 +128,11 @@ namespace godot {
         emit_signal("config_changed");
     }
 
-    void TrainPart::_process(const double p_delta) {
-        if (Engine::get_singleton()->is_editor_hint()) {
-            return;
-        }
-
+    void TrainPart::_flush_dirty_state() {
         if (dirty) {
             // emit_config_changed_signal();
             update_mover();
             dirty = false;
-        }
-
-        if (enabled) {
-            _process_mover(p_delta);
         }
 
         if (enabled_changed) {
@@ -152,11 +151,19 @@ namespace godot {
         }
     }
 
-    void TrainPart::_process_mover(const double p_delta) {
+    void TrainPart::_process_mover_thread_safe(const double p_delta) {
         if (train_controller_node != nullptr) {
             TMoverParameters *mover = train_controller_node->get_mover();
             if (mover != nullptr) {
                 _do_process_mover(mover, p_delta);
+            }
+        }
+    }
+
+    void TrainPart::_post_process_mover_sync() {
+        if (train_controller_node != nullptr) {
+            const TMoverParameters *mover = train_controller_node->get_mover();
+            if (mover != nullptr) {
                 train_controller_node->get_state().merge(get_mover_state(), true);
             }
         }

--- a/src/core/TrainPart.hpp
+++ b/src/core/TrainPart.hpp
@@ -29,9 +29,9 @@ namespace godot {
             bool dirty = false;
             TrainController *train_controller_node;
 
-            /* Jesli bedzie potrzeba rozdzielenia etapow inicjalizacji movera od jego aktualizacji,
-             * to ta metoda powinna byc zaimplementowana analogicznie do _do_update_internal_mover(),
-             * i powinna byc wywolywana przez TrainPart::initialize_mover() */
+            /* If there is a need to separate the mover initialization stages from its update,
+             * this method should be implemented similarly to _do_update_internal_mover(),
+             * and should be called by TrainPart::initialize_mover() */
             // virtual void _do_initialize_internal_mover(TMoverParameters *mover) = 0;
 
             /* _do_initialize_internal_mover() and _do_fetch_state_from_mover() are part of an internal interface
@@ -58,8 +58,12 @@ namespace godot {
             TMoverParameters *get_mover();
 
         public:
-            void _process(double p_delta) override;
-            virtual void _process_mover(double p_delta);
+            // Physics-tick-only lifecycle, driven exclusively by TrainPhysicsServer::step_physics()
+            // (never by Node's own _process()/_physics_process()): flush dirty state/enabled-change
+            // bookkeeping, then compute, then sync Godot-visible state.
+            void _flush_dirty_state();
+            virtual void _process_mover_thread_safe(double p_delta);
+            virtual void _post_process_mover_sync();
 
             void register_command(const String &p_command, const Callable &p_callback);
             void unregister_command(const String &p_command, const Callable &p_callback);
@@ -76,9 +80,9 @@ namespace godot {
             void set_enabled(bool p_value);
             bool get_enabled();
 
-            /* Jesli bedzie potrzeba rozdzielenia etapow inicjalizacji movera od jego aktualizacji,
-             * to ta metoda powinna byc zaimplementowana analogicznie do update_mover(),
-             * i powinna byc wywolywana z poziomu TrainController::initialize_mover() */
+            /* If there is a need to separate the mover initialization stages from its update,
+             * this method should be implemented similarly to update_mover(),
+             * and should be called from TrainController::initialize_mover() */
             // void initialize_mover(TrainController *train_controller_node);
 
             /* High level method for updating the state of the Mover */

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -1,4 +1,5 @@
 #include "utils.hpp"
+#include "../maszyna/utilities.h"
 
 #include <random>
 #include <sstream>
@@ -22,4 +23,25 @@ namespace libmaszyna::utils {
         }
         return ss.str();
     }
+
+    // Backing engines for Maszyna::Random()/LocalRandom() (McZapkie's physics code calls these
+    // unqualified, via the `using namespace Maszyna;` in hamulce.h). thread_local because
+    // TrainPhysicsServer steps independent consists concurrently on WorkerThreadPool tasks — a
+    // single shared engine would be a data race if any physics call chain reaches these (currently
+    // none do on the live per-tick path; this is cheap insurance against a future change that
+    // re-enables one that does).
+    thread_local std::mt19937 random_engine;
+    thread_local std::mt19937 local_random_engine;
 } // namespace libmaszyna::utils
+
+namespace Maszyna {
+    double Random(double a, double b) {
+        const unsigned long val = libmaszyna::utils::random_engine();
+        return interpolate(a, b, static_cast<double>(val) / libmaszyna::utils::random_engine.max());
+    }
+
+    double LocalRandom(double a, double b) {
+        const unsigned long val = libmaszyna::utils::local_random_engine();
+        return interpolate(a, b, static_cast<double>(val) / libmaszyna::utils::local_random_engine.max());
+    }
+} // namespace Maszyna

--- a/src/doors/TrainDoors.cpp
+++ b/src/doors/TrainDoors.cpp
@@ -183,10 +183,6 @@ namespace godot {
         p_state["doors_right_step_operating"] = right_door.step_folding || right_door.step_unfolding;
     }
 
-    void TrainDoors::_do_process_mover(TMoverParameters *p_mover, const double p_delta) {
-        p_mover->update_doors(p_delta);
-    }
-
     void TrainDoors::next_permit_preset() {
         TMoverParameters *mover = get_mover();
         ASSERT_MOVER(mover);

--- a/src/doors/TrainDoors.hpp
+++ b/src/doors/TrainDoors.hpp
@@ -10,7 +10,9 @@ namespace godot {
         protected:
             void _do_update_internal_mover(TMoverParameters *p_mover) override;
             void _do_fetch_state_from_mover(TMoverParameters *p_mover, Dictionary &p_state) override;
-            void _do_process_mover(TMoverParameters *p_mover, double p_delta) override;
+            // No _do_process_mover() override: McZapkie already calls update_doors() automatically every
+            // tick from within compute_movement_() (the shared tail of ComputeMovement/FastComputeMovement),
+            // so a wrapper-side call here would just be a duplicate, double-advancing door timers.
             void _register_commands() override;
             void _unregister_commands() override;
 

--- a/src/maszyna/utilities.cpp
+++ b/src/maszyna/utilities.cpp
@@ -16,13 +16,9 @@ Copyright (C) 2007-2014 Maciej Cierniak
 #include "utilities.h"
 #include <algorithm>
 #include <iomanip>
-#include <random>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unordered_map>
-
-#define RANDOM_ENGINE_TYPE std::mt19937
-#define LOCAL_RANDOM_ENGINE_TYPE std::mt19937
 
 namespace Maszyna {
 
@@ -32,8 +28,10 @@ namespace Maszyna {
     bool DebugCameraFlag = false;
     bool DebugTractionFlag = false;
 
-    RANDOM_ENGINE_TYPE random_engine;
-    LOCAL_RANDOM_ENGINE_TYPE local_random_engine;
+    // Random()/LocalRandom() are defined in src/core/utils.cpp, not here: the actual RNG engines
+    // (and the thread_local storage needed for them to be safe under TrainPhysicsServer's
+    // WorkerThreadPool-based concurrent consist stepping) live in our own code, not in this
+    // vendored-adjacent Maszyna utility file.
 
     double Max0R(double x1, double x2) {
         if (x1 > x2)
@@ -99,16 +97,6 @@ namespace Maszyna {
             } else {
                 return false;
             }
-    }
-
-    double Random(double a, double b) {
-        unsigned long val = random_engine();
-        return interpolate(a, b, (double)val / random_engine.max());
-    }
-
-    double LocalRandom(double a, double b) {
-        unsigned long val = local_random_engine();
-        return interpolate(a, b, (double)val / random_engine.max());
     }
 
     bool FuzzyLogic(double Test, double Threshold, double Probability) {

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -31,6 +31,7 @@
 #include "resources/engines/WWListItem.hpp"
 #include "resources/lighting/LightListItem.hpp"
 #include "resources/load/LoadListItem.hpp"
+#include "systems/TrainPhysicsServer.hpp"
 #include "systems/TrainSecuritySystem.hpp"
 #include "wheels/TrainWheels.hpp"
 #include <gdextension_interface.h>
@@ -43,6 +44,7 @@
 using namespace godot;
 
 TrainSystem *train_system_singleton = nullptr;
+TrainPhysicsServer *train_physics_server_singleton = nullptr;
 GameLog *game_log_singleton = nullptr;
 E3DParser *e3d_parser_singleton = nullptr;
 UserSettings *user_settings_singleton = nullptr;
@@ -80,6 +82,7 @@ void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
         GDREGISTER_CLASS(TrainWheels);
         GDREGISTER_CLASS(TrainSecuritySystem);
         GDREGISTER_CLASS(TrainSystem);
+        GDREGISTER_CLASS(TrainPhysicsServer);
         GDREGISTER_CLASS(TrainLighting)
         GDREGISTER_CLASS(GameLog);
         GDREGISTER_CLASS(WWListItem);
@@ -94,13 +97,15 @@ void initialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
 
         user_settings_singleton = memnew(UserSettings);
         train_system_singleton = memnew(TrainSystem);
+        train_physics_server_singleton = memnew(TrainPhysicsServer);
         game_log_singleton = memnew(GameLog);
         e3d_parser_singleton = memnew(E3DParser);
 
-        Engine::get_singleton()->register_singleton("UserSettings", user_settings_singleton); // 1
-        Engine::get_singleton()->register_singleton("E3DParser", e3d_parser_singleton);       // 2
-        Engine::get_singleton()->register_singleton("GameLog", game_log_singleton);           // 3
-        Engine::get_singleton()->register_singleton("TrainSystem", train_system_singleton);   // 4
+        Engine::get_singleton()->register_singleton("UserSettings", user_settings_singleton);              // 1
+        Engine::get_singleton()->register_singleton("E3DParser", e3d_parser_singleton);                    // 2
+        Engine::get_singleton()->register_singleton("GameLog", game_log_singleton);                        // 3
+        Engine::get_singleton()->register_singleton("TrainSystem", train_system_singleton);                // 4
+        Engine::get_singleton()->register_singleton("TrainPhysicsServer", train_physics_server_singleton); // 5
 
         e3d_resource_format_loader.instantiate();
         ogg_vorbis_format_loader.instantiate();
@@ -130,6 +135,10 @@ void uninitialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
         Engine::get_singleton()->unregister_singleton("TrainSystem"); // 4
     }
 
+    if (Engine::get_singleton()->has_singleton("TrainPhysicsServer")) {
+        Engine::get_singleton()->unregister_singleton("TrainPhysicsServer"); // 5
+    }
+
     if (Engine::get_singleton()->has_singleton("GameLog")) {
         Engine::get_singleton()->unregister_singleton("GameLog"); // 3
     }
@@ -145,6 +154,11 @@ void uninitialize_libmaszyna_module(const ModuleInitializationLevel p_level) {
     if (train_system_singleton != nullptr) { // 4
         memdelete(train_system_singleton);
         train_system_singleton = nullptr;
+    }
+
+    if (train_physics_server_singleton != nullptr) { // 5
+        memdelete(train_physics_server_singleton);
+        train_physics_server_singleton = nullptr;
     }
 
     if (game_log_singleton != nullptr) { // 3

--- a/src/systems/TrainPhysicsServer.cpp
+++ b/src/systems/TrainPhysicsServer.cpp
@@ -1,0 +1,222 @@
+#include "../core/TrainController.hpp"
+#include "../core/TrainPart.hpp"
+#include "TrainPhysicsServer.hpp"
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/classes/worker_thread_pool.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
+
+namespace godot {
+    TrainPhysicsServer *TrainPhysicsServer::get_instance() {
+        return dynamic_cast<TrainPhysicsServer *>(Engine::get_singleton()->get_singleton("TrainPhysicsServer"));
+    }
+
+    void TrainPhysicsServer::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("step_physics", "delta"), &TrainPhysicsServer::step_physics);
+        ClassDB::bind_method(D_METHOD("_physics_process_callback"), &TrainPhysicsServer::_physics_process_callback);
+        ClassDB::bind_method(D_METHOD("_step_consist_task", "index"), &TrainPhysicsServer::_step_consist_task);
+    }
+
+    void TrainPhysicsServer::_setup_connection() {
+        SceneTree *tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+        if (tree != nullptr) {
+            const Callable cb = Callable(this, "_physics_process_callback");
+            if (!tree->is_connected("physics_frame", cb)) {
+                tree->connect("physics_frame", cb);
+            }
+        }
+    }
+
+    void TrainPhysicsServer::_physics_process_callback() {
+        const SceneTree *tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+        if (tree != nullptr) {
+            // SceneTree has no get_physics_process_delta_time() of its own; get_root() is a Node,
+            // which does.
+            const double delta = tree->get_root()->get_physics_process_delta_time();
+            step_physics(delta);
+        }
+    }
+
+    void TrainPhysicsServer::register_controller(TrainController *p_controller) {
+        if (!active_controllers.has(p_controller)) {
+            active_controllers.push_back(p_controller);
+        }
+        _setup_connection();
+    }
+
+    void TrainPhysicsServer::unregister_controller(TrainController *p_controller) {
+        active_controllers.erase(p_controller);
+    }
+
+    void TrainPhysicsServer::register_part(TrainPart *p_part) {
+        if (!active_parts.has(p_part)) {
+            active_parts.push_back(p_part);
+        }
+        _setup_connection();
+    }
+
+    void TrainPhysicsServer::unregister_part(TrainPart *p_part) {
+        active_parts.erase(p_part);
+    }
+
+    RID TrainPhysicsServer::create_mover(
+            const double p_initial_velocity, const std::string &p_type_name, const std::string &p_name,
+            const int p_cabin_number) {
+        auto *mover = new TMoverParameters(p_initial_velocity, p_type_name, p_name, p_cabin_number);
+        return movers.make_rid(mover);
+    }
+
+    TMoverParameters *TrainPhysicsServer::get_mover(const RID p_mover) const {
+        return movers.get_or_null(p_mover);
+    }
+
+    void TrainPhysicsServer::free_mover(const RID p_mover) {
+        if (TMoverParameters *mover = movers.get_or_null(p_mover); mover != nullptr) {
+            movers.free(p_mover);
+            delete mover;
+        }
+    }
+
+    // Groups registered controllers into connected consists (chains of physically/electrically/
+    // pneumatically coupled vehicles, linked via TMoverParameters::Couplers[end].Connected) so that
+    // step_physics() can dispatch one WorkerThreadPool task per consist: vehicles in the same consist
+    // read and write each other's state during a tick (brake-pipe pressure propagation, coupled command
+    // cascades) and must be stepped sequentially, on one thread; vehicles in different consists share no
+    // state and can run fully concurrently. Each consist's members are ordered the same way
+    // active_controllers already is, to preserve today's single-threaded, order-dependent numerical
+    // behavior (e.g. which coupled car's brake-pipe "push" lands first in a given tick).
+    Vector<Vector<TrainController *>> TrainPhysicsServer::_discover_consists() const {
+        HashMap<TMoverParameters *, TrainController *> owner_by_mover;
+        for (auto *const controller: active_controllers) {
+            if (TMoverParameters *mover = controller->get_mover(); mover != nullptr) {
+                owner_by_mover.insert(mover, controller);
+            }
+        }
+
+        HashMap<TrainController *, TrainController *> representative_of;
+
+        for (auto *const controller: active_controllers) {
+            if (representative_of.has(controller)) {
+                continue;
+            }
+
+            TMoverParameters *mover = controller->get_mover();
+            if (mover == nullptr) {
+                representative_of.insert(controller, controller);
+                continue;
+            }
+
+            // Walk the coupled chain in both directions (each vehicle has at most two neighbors:
+            // front/rear), collecting every controller reachable from this one.
+            Vector<TMoverParameters *> to_visit;
+            to_visit.push_back(mover);
+            HashSet<TMoverParameters *> seen_movers;
+            seen_movers.insert(mover);
+            Vector<TrainController *> chain;
+            chain.push_back(controller);
+
+            while (!to_visit.is_empty()) {
+                TMoverParameters *current = to_visit[to_visit.size() - 1];
+                to_visit.resize(to_visit.size() - 1);
+
+                for (const auto & coupler : current->Couplers) {
+                    TMoverParameters *neighbor = coupler.Connected;
+                    if (neighbor == nullptr || seen_movers.has(neighbor)) {
+                        continue;
+                    }
+                    seen_movers.insert(neighbor);
+                    to_visit.push_back(neighbor);
+                    if (TrainController *const *neighbor_controller = owner_by_mover.getptr(neighbor);
+                        neighbor_controller != nullptr) {
+                        chain.push_back(*neighbor_controller);
+                    }
+                }
+            }
+
+            for (auto *const chain_controller: chain) {
+                representative_of.insert(chain_controller, controller);
+            }
+        }
+
+        HashMap<TrainController *, int> consist_index_of;
+        Vector<Vector<TrainController *>> consists;
+
+        for (auto *const controller: active_controllers) {
+            TrainController *representative = representative_of.has(controller) ? representative_of[controller] : controller;
+            if (!consist_index_of.has(representative)) {
+                consist_index_of.insert(representative, static_cast<int>(consists.size()));
+                consists.push_back(Vector<TrainController *>());
+            }
+            consists.write[consist_index_of[representative]].push_back(controller);
+        }
+
+        return consists;
+    }
+
+    void TrainPhysicsServer::_step_consist_task(const int p_index) {
+        for (auto *const controller: current_consists[p_index]) {
+            controller->_process_mover_thread_safe(current_delta);
+        }
+    }
+
+    void TrainPhysicsServer::step_physics(const double p_delta) {
+        // Simulation (McZapkie compute: ComputeTotalForce + ComputeMovement, pure data computation,
+        // no Godot API calls) runs in parallel, one WorkerThreadPool task per connected consist.
+        // Coupled vehicles share mutable state (brake-pipe pressure, command cascades via
+        // SendCtrlToNext) and must stay on one thread; uncoupled vehicles/consists share nothing and
+        // run fully concurrently. wait_for_group_task_completion() blocks the main thread until every
+        // consist has finished, so no command-mutating TrainController/TrainPart method (battery,
+        // main_controller_increase/decrease, etc. — all main-thread-only, dispatched via Godot
+        // signals/Callables) can ever run concurrently with a consist task.
+        // Pre-process (main thread): flush any dirty config/enabled-state before this tick's
+        // simulation runs, so config changes apply exactly once per physics tick, synchronized with
+        // the compute that follows — previously this ran on Node's own _process() (idle/render rate),
+        // decoupled from the simulation's actual cadence. Unconditional (not gated by get_enabled()):
+        // a part that just became disabled still needs its enabled-transition handled here.
+        for (auto *const active_controller: active_controllers) {
+            active_controller->_update_mover_config_if_dirty();
+        }
+        for (auto *const active_part: active_parts) {
+            active_part->_flush_dirty_state();
+        }
+
+        current_delta = p_delta;
+        current_consists = _discover_consists();
+
+        if (current_consists.size() > 1) {
+            // Actually worth farming out: more than one independent consist to compute.
+            const int64_t group_id = WorkerThreadPool::get_singleton()->add_group_task(
+                    Callable(this, "_step_consist_task"), static_cast<int32_t>(current_consists.size()), -1, true,
+                    "TrainPhysicsServer::step_consists");
+            WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_id);
+        } else if (current_consists.size() == 1) {
+            // Only one consist (the common case: a single train, or everything coupled into one
+            // consist) — nothing to parallelize against, so skip WorkerThreadPool dispatch/wake-up
+            // latency entirely and step it inline. That overhead is pure loss here and, left in,
+            // measurably slows down the effective simulation rate tick-over-tick for the common case.
+            _step_consist_task(0);
+        }
+        current_consists.clear();
+
+        // Parts: some (e.g. TrainWheels) drive Godot Node3D transforms directly — Godot scene-tree API,
+        // must stay on the main thread.
+        for (auto *const active_part: active_parts) {
+            if (active_part->get_enabled()) {
+                active_part->_process_mover_thread_safe(p_delta);
+            }
+        }
+
+        // Post process (update Godot dictionaries and emit signals safely on main thread)
+        for (auto *const active_controller: active_controllers) {
+            active_controller->_post_process_mover_sync();
+        }
+
+        for (auto *const active_part: active_parts) {
+            if (active_part->get_enabled()) {
+                active_part->_post_process_mover_sync();
+            }
+        }
+    }
+} // namespace godot

--- a/src/systems/TrainPhysicsServer.hpp
+++ b/src/systems/TrainPhysicsServer.hpp
@@ -1,0 +1,73 @@
+#pragma once
+#include "../maszyna/McZapkie/MOVER.h"
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/templates/rid_owner.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/rid.hpp>
+#include <string>
+
+namespace godot {
+    class TrainController;
+    class TrainPart;
+
+    class TrainPhysicsServer : public Object {
+            GDCLASS(TrainPhysicsServer, Object);
+
+        private:
+            Vector<TrainController *> active_controllers;
+            Vector<TrainPart *> active_parts;
+
+            // Centralized ownership of the McZapkie simulation instances, mirroring how Godot's own
+            // servers (e.g. PhysicsServer3D) own their data behind opaque RIDs instead of nodes holding
+            // raw pointers. RID_PtrOwner stores the externally-allocated TMoverParameters* as-is (no
+            // copy of the pointee, unlike RID_Owner). THREAD_SAFE=true guards make_rid()/free()/
+            // get_or_null() against concurrent registration while worker tasks may be reading the table
+            // during step_physics(). `mutable` so get_mover() can stay const like TrainController's does.
+            mutable RID_PtrOwner<TMoverParameters, true> movers;
+
+            // Scratch state, valid only for the duration of a single step_physics() call.
+            Vector<Vector<TrainController *>> current_consists;
+            double current_delta = 0.0;
+
+            Vector<Vector<TrainController *>> _discover_consists() const;
+
+        public:
+            static TrainPhysicsServer *get_instance();
+
+            void register_controller(TrainController *p_controller);
+            void unregister_controller(TrainController *p_controller);
+
+            void register_part(TrainPart *p_part);
+            void unregister_part(TrainPart *p_part);
+
+            RID create_mover(double p_initial_velocity, const std::string &p_type_name, const std::string &p_name, int p_cabin_number);
+            TMoverParameters *get_mover(RID p_mover) const;
+            void free_mover(RID p_mover);
+
+            void _setup_connection();
+            void _physics_process_callback();
+
+            // The entire per-tick lifecycle for every registered TrainController/TrainPart lives here,
+            // driven by Godot's physics_frame signal — never by Node's own _process()/_physics_process()
+            // — so config flushing, simulation, and state sync all happen exactly once per physics tick,
+            // in this fixed order: (1) flush dirty config/enabled-state (main thread); (2) simulation
+            // (McZapkie compute, no Godot API calls) in parallel, one WorkerThreadPool task per connected
+            // consist (coupled vehicles must stay on one thread, see _discover_consists()); (3) parts and
+            // Dictionary/signal sync, sequential on the main thread (Godot Object/Variant API). No
+            // command-mutating TrainController/TrainPart method may be called while a consist task is in
+            // flight — wait_for_group_task_completion() blocks the main thread until every consist
+            // finishes before step (3) starts.
+            void step_physics(double p_delta);
+            void _step_consist_task(int p_index);
+
+            // Safety note (not code): TMoverParameters::ComputeMass() reads the file-scope
+            // Maszyna::simulation::Weights map (MOVER.h) on the hot path. It's never populated
+            // anywhere in the repo today (read-only/inert), which is why concurrent consist tasks
+            // reading it is currently safe. If it's ever populated at runtime, that must happen
+            // before any step_physics() call is in flight, not concurrently with one.
+
+        protected:
+            static void _bind_methods();
+    };
+} // namespace godot


### PR DESCRIPTION
Bunch of ideas on how we can optimize logic in the future. Not necessarily needed to be implemented as-is in this PR, but PR is ready to be merged, I think

**Note: This was AI-assisted to speed up the development process, so code quality might not be the best, it rather is a working PoC than a full feature**

Before:

avg. 92 FPS (I'll update screenshots later, didn't see that, sorry)
<img width="1667" height="575" alt="image" src="https://github.com/user-attachments/assets/4e1aea0c-8d85-46f1-95c2-a1a935632540" />
<img width="343" height="433" alt="image" src="https://github.com/user-attachments/assets/3d2769b5-0f69-476c-83eb-c3919c40f6aa" />


After:

avg. 98 FPS
<img width="1604" height="573" alt="image" src="https://github.com/user-attachments/assets/6c5bcd59-62a2-4dda-8acb-8abe8c8e7dab" />
<img width="338" height="468" alt="image" src="https://github.com/user-attachments/assets/e79dc913-1892-4899-ac97-98ef55f4c54c" />


For now only adds some FPS, but in the long run it might be more helpful moving the physics/state to a derived Server with some multithreading